### PR TITLE
Fix GitHub Pages deployment - add Jekyll build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,10 +28,14 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs'
 
   deploy:
     environment:


### PR DESCRIPTION
## Problem

The GitHub Pages deployment was uploading raw markdown files without building them with Jekyll first, resulting in 404 errors when accessing https://yeraze.github.io/eeroVista/

## Solution

Added the `actions/jekyll-build-pages@v1` action to the Pages workflow to properly build the Jekyll site before deployment.

## Changes

- Updated `.github/workflows/pages.yml` to include Jekyll build step
- Removed hardcoded path in upload artifact step (uses default `_site` directory)

## Testing

Will be verified after merge by checking that the Pages URL loads correctly.