### PR TITLE
Fix attestation permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to fix attestation step in release workflow

## Issue
The attestation step was failing with:
```
Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

## Solution
The `actions/attest-build-provenance@v1` action requires the `id-token: write` permission to request OIDC tokens for generating cryptographic attestations. This change adds that permission to the `build-and-push` job.

## Impact
- Attestation will now complete successfully on releases
- Adds cryptographic provenance signatures to Docker images for supply chain security
- Docker images already build and publish successfully; this just completes the final attestation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)