### PR TITLE
Fix release workflow attestation permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Fixed release workflow failure by adding `attestations: write` permission
- Resolved "Resource not accessible by integration" error during attestation step
- Docker builds were succeeding, but attestation publishing was failing due to missing permissions

## Root Cause

The `actions/attest-build-provenance@v1` action requires the `attestations: write` permission to create and publish build attestations to the container registry. The workflow had `contents`, `packages`, and `id-token` permissions but was missing `attestations`.

## Changes

- Added `attestations: write` to the permissions section in `.github/workflows/release.yml`

## Test Plan

- [x] Reviewed the last 5 release workflow runs and confirmed they all failed at the attestation step
- [x] Verified the error message indicates missing permissions
- [x] Validated the YAML syntax of the workflow file
- [ ] After merging, trigger a new release to verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)