### PR TITLE
Improve device detail charts and bandwidth formatting

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -10,6 +10,23 @@
   - Track guest network connection status separately from main network
 
 ## Completed
+- [x] Improved bandwidth formatting for small values (2025-10-21)
+  - Updated formatBytes() to show KB for values < 1 MB (e.g., "30.72 KB" instead of "0.03 MB")
+  - Added Bytes display for values < 1 KB
+  - Updated chart y-axis labels to use smart formatting (automatically shows GB/MB/KB/Bytes)
+  - Changed y-axis title from "Data Usage (MB)" to "Data Usage" for accuracy
+  - Fixes devices with low bandwidth showing misleading "0 MB" values
+- [x] Chart data completeness and hourly view fixes (2025-10-21)
+  - Fixed device bandwidth endpoint to return full date range (7/30 days) with zeros for missing data
+  - Fixed device hourly chart to show only today's data (UTC timezone parsing issue)
+  - Aligned Device Details popup bandwidth charts with Dashboard implementation
+  - Added incomplete data indicator (lighter colors for today's data)
+  - Added category scale to prevent "Invalid date" x-axis issues
+  - Added "(incomplete)" notation in tooltips for today's data
+  - Added `is_incomplete` flag to device bandwidth endpoint matching network endpoint
+  - Corrected collection interval calculation from 60s to 30s
+  - Fixed UTC timestamp parsing by appending 'Z' suffix for correct timezone conversion
+  - Ensures consistent chart behavior across Dashboard and Device Details views
 - [x] v0.9.0 Release - IP reservations and port forwards tracking (PR #23)
   - Backend: Database models, data collector, and API endpoints for DHCP reservations and port forwards
   - Frontend: Tabbed display on Nodes page, visual indicators in Devices List (🔒 for reserved IPs, 🔀 for port forwards)
@@ -51,4 +68,4 @@
 
 ---
 
-*Last updated: 2025-10-20*
+*Last updated: 2025-10-21*

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -670,6 +670,8 @@ async def get_device_bandwidth_total(
 
     try:
         from datetime import timedelta, date
+        from src.config import get_settings
+        from zoneinfo import ZoneInfo
 
         with get_db_context() as db:
             from src.models.database import Device, DailyBandwidth
@@ -680,9 +682,17 @@ async def get_device_bandwidth_total(
                 raise HTTPException(status_code=404, detail="Device not found")
 
             # Get daily bandwidth records
-            # Use UTC date to match UTC timestamps in database
-            today_utc = datetime.utcnow().date()
-            since_date = today_utc - timedelta(days=days - 1)
+            # Use local timezone to match how data collection stores dates
+            settings = get_settings()
+            tz = settings.get_timezone()
+            now_local = datetime.now(tz)
+            today_local = now_local.date()
+            since_date = today_local - timedelta(days=days - 1)
+
+            # Generate complete date range
+            all_dates = [since_date + timedelta(days=i) for i in range(days)]
+
+            # Fetch records from database
             daily_records = (
                 db.query(DailyBandwidth)
                 .filter(
@@ -693,18 +703,33 @@ async def get_device_bandwidth_total(
                 .all()
             )
 
+            # Create a lookup map for existing records
+            records_by_date = {record.date: record for record in daily_records}
+
             # Calculate totals
             total_download = sum(record.download_mb for record in daily_records)
             total_upload = sum(record.upload_mb for record in daily_records)
 
-            # Format daily breakdown
+            # Format daily breakdown with complete date range (fill zeros for missing days)
             daily_breakdown = []
-            for record in daily_records:
-                daily_breakdown.append({
-                    "date": record.date.isoformat(),
-                    "download_mb": round(record.download_mb, 2),
-                    "upload_mb": round(record.upload_mb, 2),
-                })
+            for date_obj in all_dates:
+                is_today = date_obj == today_local
+                if date_obj in records_by_date:
+                    record = records_by_date[date_obj]
+                    daily_breakdown.append({
+                        "date": date_obj.isoformat(),
+                        "download_mb": round(record.download_mb, 2),
+                        "upload_mb": round(record.upload_mb, 2),
+                        "is_incomplete": is_today,  # Today's data is still being collected
+                    })
+                else:
+                    # No data for this date - fill with zeros
+                    daily_breakdown.append({
+                        "date": date_obj.isoformat(),
+                        "download_mb": 0.0,
+                        "upload_mb": 0.0,
+                        "is_incomplete": False,
+                    })
 
             return {
                 "device": {
@@ -714,7 +739,7 @@ async def get_device_bandwidth_total(
                 "period": {
                     "days": days,
                     "start_date": since_date.isoformat(),
-                    "end_date": today_utc.isoformat(),
+                    "end_date": today_local.isoformat(),
                 },
                 "totals": {
                     "download_mb": round(total_download, 2),

--- a/src/templates/devices.html
+++ b/src/templates/devices.html
@@ -869,8 +869,16 @@
     function formatBytes(mb) {
         if (mb >= 1000) {
             return `${(mb / 1000).toFixed(2)} GB`;
+        } else if (mb >= 1) {
+            return `${mb.toFixed(2)} MB`;
+        } else if (mb >= 0.001) {
+            // Convert MB to KB (1 MB = 1024 KB)
+            return `${(mb * 1024).toFixed(2)} KB`;
+        } else if (mb > 0) {
+            // Convert MB to Bytes (1 MB = 1024 * 1024 Bytes)
+            return `${(mb * 1024 * 1024).toFixed(0)} Bytes`;
         }
-        return `${mb.toFixed(2)} MB`;
+        return '0 Bytes';
     }
 
     // Load and render bandwidth chart for device
@@ -918,6 +926,14 @@
         const downloadData = dailyData.map(d => d.download_mb);
         const uploadData = dailyData.map(d => d.upload_mb);
 
+        // Use lighter colors for incomplete (today's) data
+        const downloadColors = dailyData.map(d =>
+            d.is_incomplete ? 'rgba(30, 102, 245, 0.4)' : 'rgba(30, 102, 245, 0.8)'
+        );
+        const uploadColors = dailyData.map(d =>
+            d.is_incomplete ? 'rgba(136, 57, 239, 0.4)' : 'rgba(136, 57, 239, 0.8)'
+        );
+
         bandwidthChart = new Chart(ctx, {
             type: 'bar',
             data: {
@@ -926,14 +942,14 @@
                     {
                         label: 'Download',
                         data: downloadData,
-                        backgroundColor: 'rgba(30, 102, 245, 0.8)', // Catppuccin blue
+                        backgroundColor: downloadColors,
                         borderColor: 'rgb(30, 102, 245)',
                         borderWidth: 1
                     },
                     {
                         label: 'Upload',
                         data: uploadData,
-                        backgroundColor: 'rgba(136, 57, 239, 0.8)', // Catppuccin mauve
+                        backgroundColor: uploadColors,
                         borderColor: 'rgb(136, 57, 239)',
                         borderWidth: 1
                     }
@@ -956,11 +972,14 @@
                                 const dateStr = context[0].label;
                                 const [year, month, day] = dateStr.split('-').map(Number);
                                 const date = new Date(year, month - 1, day);
-                                return date.toLocaleDateString('en-US', {
+                                const formatted = date.toLocaleDateString('en-US', {
                                     weekday: 'short',
                                     month: 'short',
                                     day: 'numeric'
                                 });
+                                // Add note for incomplete data
+                                const dataPoint = dailyData[context[0].dataIndex];
+                                return dataPoint.is_incomplete ? formatted + ' (incomplete)' : formatted;
                             },
                             label: function(context) {
                                 return `${context.dataset.label}: ${formatBytes(context.parsed.y)}`;
@@ -970,6 +989,7 @@
                 },
                 scales: {
                     x: {
+                        type: 'category',  // Explicitly use category scale to prevent date parsing
                         stacked: false,
                         title: {
                             display: true,
@@ -993,14 +1013,11 @@
                         stacked: false,
                         title: {
                             display: true,
-                            text: 'Data Usage (MB)'
+                            text: 'Data Usage'
                         },
                         ticks: {
                             callback: function(value) {
-                                if (value >= 1000) {
-                                    return (value / 1000).toFixed(1) + ' GB';
-                                }
-                                return value.toFixed(0) + ' MB';
+                                return formatBytes(value);
                             }
                         }
                     }
@@ -1054,6 +1071,10 @@
                 return;
             }
 
+            // Get today's date at midnight (local timezone)
+            const now = new Date();
+            const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
             // Aggregate data by hour
             const hourlyData = Array(24).fill(null).map((_, hour) => ({
                 hour: hour,
@@ -1064,15 +1085,21 @@
             }));
 
             // Sum bandwidth rates for each hour (convert Mbps to MB by dividing by 8 and multiplying by collection interval)
-            // Approximate: Mbps * 60 seconds / 8 bits per byte ≈ MB per minute
-            const secondsPerDataPoint = 60; // Assume 1-minute collection intervals
+            // Only include data from today (local timezone)
+            const secondsPerDataPoint = 30; // 30-second collection intervals
             data.history.forEach(point => {
-                const timestamp = new Date(point.timestamp);
-                const hour = timestamp.getHours();
-                if (point.download_mbps !== null && point.upload_mbps !== null) {
-                    hourlyData[hour].download_mb += (point.download_mbps * secondsPerDataPoint) / 8;
-                    hourlyData[hour].upload_mb += (point.upload_mbps * secondsPerDataPoint) / 8;
-                    hourlyData[hour].count++;
+                // Parse UTC timestamp correctly (API timestamps are UTC but lack 'Z' suffix)
+                // Adding 'Z' tells JavaScript to parse as UTC
+                const timestamp = new Date(point.timestamp.endsWith('Z') ? point.timestamp : point.timestamp + 'Z');
+
+                // Filter: only include timestamps >= today at midnight
+                if (timestamp >= todayMidnight) {
+                    const hour = timestamp.getHours();
+                    if (point.download_mbps !== null && point.upload_mbps !== null) {
+                        hourlyData[hour].download_mb += (point.download_mbps * secondsPerDataPoint) / 8;
+                        hourlyData[hour].upload_mb += (point.upload_mbps * secondsPerDataPoint) / 8;
+                        hourlyData[hour].count++;
+                    }
                 }
             });
 
@@ -1150,6 +1177,7 @@
                 },
                 scales: {
                     x: {
+                        type: 'category',  // Explicitly use category scale to prevent parsing issues
                         stacked: false,
                         title: {
                             display: true,
@@ -1161,14 +1189,11 @@
                         stacked: false,
                         title: {
                             display: true,
-                            text: 'Data Usage (MB)'
+                            text: 'Data Usage'
                         },
                         ticks: {
                             callback: function(value) {
-                                if (value >= 1000) {
-                                    return (value / 1000).toFixed(1) + ' GB';
-                                }
-                                return value.toFixed(0) + ' MB';
+                                return formatBytes(value);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

This PR improves the device detail popup charts to align with dashboard behavior and fixes several data visualization issues:

- **Full date range display**: Device charts now show all requested days (7/30) with zeros for missing data, matching dashboard behavior
- **Accurate hourly view**: Hourly charts now correctly show only today's data instead of mixing yesterday and today
- **Better bandwidth formatting**: Small bandwidth values now display as KB or Bytes instead of misleading "0 MB"
- **Improved chart reliability**: Fixed UTC timestamp parsing and "Invalid date" x-axis issues

## Changes

### Backend (`src/api/health.py`)
- Fixed device bandwidth endpoint to return complete date range with zeros for missing days
- Added `is_incomplete` flag to device bandwidth response
- Implemented timezone-aware date handling using local timezone

### Frontend (`src/templates/devices.html`)
- Fixed hourly chart UTC timestamp parsing (append 'Z' suffix)
- Added incomplete data indicators (lighter colors, tooltips)
- Improved `formatBytes()` function:
  - Values >= 1000 MB → GB (e.g., "1.50 GB")
  - Values >= 1 MB → MB (e.g., "12.45 MB")
  - Values >= 0.001 MB → KB (e.g., "30.72 KB")
  - Values < 1 KB → Bytes (e.g., "512 Bytes")
- Updated chart y-axis to use smart formatting
- Added category scale to prevent date parsing issues
- Fixed collection interval from 60s to 30s

### Infrastructure
- Updated docker-compose ports from 8080 to 8081
- Renamed TODO.md to TODOS.md

## Test Plan

- [x] Run test suite locally (58 passed, 23 skipped)
- [ ] Verify device charts show full 7-day range with zeros for missing dates
- [ ] Verify hourly charts show only today's data (not yesterday's)
- [ ] Verify small bandwidth values display as KB (e.g., "30.72 KB" instead of "0.03 MB")
- [ ] Verify tooltips show "(incomplete)" for today's data
- [ ] Verify application runs on port 8081
- [ ] Verify TODOS.md file exists and TODO.md is removed

## Screenshots

Test with device `44:61:32:27:ce:81` which has small bandwidth values:
- Before: Shows "0 MB" for all values
- After: Shows meaningful KB values like "30.72 KB", "931.84 KB"

🤖 Generated with [Claude Code](https://claude.com/claude-code)