### PR TITLE
Fix timezone desync between dashboard and device bandwidth data

### DIFF
--- a/src/api/health.py
+++ b/src/api/health.py
@@ -1363,8 +1363,10 @@ async def get_network_bandwidth_hourly(
             hourly_query = (
                 db.query(
                     # Extract hour with timezone offset adjustment
+                    # Cast strftime result to integer BEFORE doing math
+                    # Use ((x % 24) + 24) % 24 to handle negative results correctly in SQLite
                     func.cast(
-                        (func.strftime('%H', DeviceConnection.timestamp) + offset_hours) % 24,
+                        ((func.cast(func.strftime('%H', DeviceConnection.timestamp), Integer) + offset_hours) % 24 + 24) % 24,
                         Integer
                     ).label('hour'),
                     func.sum(

--- a/src/templates/devices.html
+++ b/src/templates/devices.html
@@ -1146,9 +1146,8 @@
             // Only include data from today (local timezone)
             const secondsPerDataPoint = 30; // 30-second collection intervals
             data.history.forEach(point => {
-                // Parse UTC timestamp correctly (API timestamps are UTC but lack 'Z' suffix)
-                // Adding 'Z' tells JavaScript to parse as UTC
-                const timestamp = new Date(point.timestamp.endsWith('Z') ? point.timestamp : point.timestamp + 'Z');
+                // Parse timezone-aware timestamp (API returns ISO timestamps with timezone offset)
+                const timestamp = new Date(point.timestamp);
 
                 // Filter: only include timestamps >= today at midnight
                 if (timestamp >= todayMidnight) {


### PR DESCRIPTION
## Summary
Fixes timezone-related issues that caused hourly bandwidth data to be misaligned between the dashboard and device details views.

## Problem
Users in non-UTC timezones experienced a desync where:
- Device details showed bandwidth data for certain hours (e.g., hour 20:00 EDT)
- Dashboard hourly view showed 0 MB for the same hours
- The issue affected hours 20-23 in EDT (UTC-4), which map to UTC hours 0-3

## Root Causes

### 1. Device Bandwidth History API
- Used `datetime.utcnow()` without timezone conversion
- Returned UTC timestamps without timezone information
- Inconsistent with dashboard's timezone-aware approach

### 2. JavaScript Timestamp Parsing
- Expected UTC timestamps and added 'Z' suffix
- Broke when API started returning timezone-aware timestamps
- Caused hourly aggregation to fail silently

### 3. SQLite Modulo Operator Bug
- SQLite's `%` operator returns negative results for negative inputs
- Formula: `(1 + (-4)) % 24 = -3` instead of `21`
- Caused hours 20-23 EDT to be grouped as hours -4, -3, -2, -1

## Solutions

### Device Bandwidth History API (src/api/health.py:735-746, 759-771)
```python
# Use configured timezone for time calculations
settings = get_settings()
tz = settings.get_timezone()
now_local = datetime.now(tz)
cutoff_local = now_local - timedelta(hours=hours)
cutoff_time = cutoff_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)

# Return timestamps in local timezone
timestamp_utc = conn.timestamp.replace(tzinfo=ZoneInfo("UTC"))
timestamp_local = timestamp_utc.astimezone(tz)
```

### JavaScript Timestamp Parsing (src/templates/devices.html:1149-1150)
```javascript
// Parse timezone-aware timestamp directly
const timestamp = new Date(point.timestamp);
```

### SQLite Modulo Fix (src/api/health.py:1367-1370)
```python
# Use ((x % 24) + 24) % 24 to handle negative results correctly
func.cast(
    ((func.cast(func.strftime('%H', DeviceConnection.timestamp), Integer) + offset_hours) % 24 + 24) % 24,
    Integer
).label('hour'),
```

## Testing
- [x] Verified device details "Hourly" tab shows data
- [x] Verified dashboard hourly view shows matching data
- [x] Tested with EDT timezone (UTC-4)
- [x] Verified hours 20-23 now display correctly (previously showed 0)
- [x] Confirmed ~1.9GB traffic in hour 20 appears in both views

## Example Results
**Before:** Dashboard hour 20:00 showed 0 MB, device details showed 1.66 GB
**After:** Both dashboard and device details show ~1.9 GB for hour 20:00

## Breaking Changes
None - fully backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)