### PR TITLE
Fix firmware update banner flashing on page load

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<div id="update-banner" style="display: none; background: var(--peach); color: var(--base); padding: 1rem 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; display: flex; align-items: center; gap: 1rem;">
+<div id="update-banner" style="display: none; background: var(--peach); color: var(--base); padding: 1rem 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; align-items: center; gap: 1rem;">
     <div style="font-size: 1.5rem;">⚠️</div>
     <div style="flex: 1;">
         <div style="font-weight: 600; font-size: 1rem;">Firmware Update Available</div>


### PR DESCRIPTION
## Summary

- Fixed firmware update banner briefly appearing on page load before being hidden
- Removed conflicting CSS `display` property that caused the flash

## Details

The update banner element had both `display: none;` and `display: flex;` in its inline styles. The `display: flex;` property came last and overrode the `none` value, causing the banner to be visible on initial page load. The JavaScript would then hide it moments later after checking the API response, creating a visual flash.

**Changes:**
- Removed the duplicate `display: flex;` property from the banner's inline styles
- Banner now starts hidden and only becomes visible when JavaScript confirms updates are available via the API

## Test Plan

- [x] Load the dashboard page
- [x] Verify the orange firmware update banner does not flash on initial load
- [x] Verify the banner remains hidden when no updates are available
- [x] Banner will properly show when `data.updates_available` is true (controlled by JavaScript at dashboard.html:163)

## Notes

This is a frontend-only change (HTML/CSS) that doesn't affect any backend logic or API endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)