### PR TITLE
Add encryption key validation with helpful error messages

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """eeroVista - Read-only monitoring for Eero mesh networks."""
 
-__version__ = "2.4.2"
+__version__ = "2.4.3"

--- a/src/utils/encryption.py
+++ b/src/utils/encryption.py
@@ -1,15 +1,36 @@
 """Encryption utilities for storing sensitive data."""
 
 import base64
+import logging
 import os
+import sys
 from typing import Optional
 
 from cryptography.fernet import Fernet
 
 from src.config import get_settings
 
+logger = logging.getLogger(__name__)
+
 # Global cache for generated encryption key (persists during app lifetime)
 _cached_encryption_key: Optional[bytes] = None
+
+
+def validate_encryption_key(key: bytes) -> bool:
+    """Validate that a key is a valid Fernet key.
+
+    Args:
+        key: The key to validate
+
+    Returns:
+        True if valid, False otherwise
+    """
+    try:
+        # Try to create a Fernet instance with the key
+        Fernet(key)
+        return True
+    except Exception:
+        return False
 
 
 def get_encryption_key() -> bytes:
@@ -21,6 +42,29 @@ def get_encryption_key() -> bytes:
     if settings.encryption_key:
         # Use provided key from environment
         key = settings.encryption_key.encode()
+
+        # Validate the provided key
+        if not validate_encryption_key(key):
+            logger.error("=" * 80)
+            logger.error("INVALID ENCRYPTION_KEY DETECTED")
+            logger.error("=" * 80)
+            logger.error("")
+            logger.error("The ENCRYPTION_KEY environment variable is set but is not a valid Fernet key.")
+            logger.error("A Fernet key must be 32 url-safe base64-encoded bytes.")
+            logger.error("")
+            logger.error("To fix this issue, choose one of these options:")
+            logger.error("")
+            logger.error("Option 1 (Recommended): Remove ENCRYPTION_KEY and let it auto-generate")
+            logger.error("  - Remove the ENCRYPTION_KEY from your docker-compose.yml or .env file")
+            logger.error("  - Restart the container")
+            logger.error("")
+            logger.error("Option 2: Generate a valid Fernet key")
+            logger.error("  - Run: python3 -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"")
+            logger.error("  - Set ENCRYPTION_KEY to the generated value")
+            logger.error("")
+            logger.error("=" * 80)
+            sys.exit(1)
+
     elif _cached_encryption_key is not None:
         # Use cached generated key
         key = _cached_encryption_key
@@ -29,6 +73,7 @@ def get_encryption_key() -> bytes:
         # This persists for the lifetime of the application
         key = Fernet.generate_key()
         _cached_encryption_key = key
+        logger.info("Generated new encryption key (will persist for application lifetime)")
 
     return key
 
@@ -46,9 +91,6 @@ def encrypt_value(value: str) -> str:
 
 def decrypt_value(encrypted_value: str) -> Optional[str]:
     """Decrypt a string value."""
-    import logging
-    logger = logging.getLogger(__name__)
-
     if not encrypted_value:
         return None
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,142 @@
+"""Tests for encryption utilities."""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from cryptography.fernet import Fernet
+
+from src.utils.encryption import (
+    validate_encryption_key,
+    get_encryption_key,
+    encrypt_value,
+    decrypt_value,
+)
+
+
+class TestEncryptionKeyValidation:
+    """Test encryption key validation."""
+
+    def test_validate_encryption_key_valid(self):
+        """Test that a valid Fernet key passes validation."""
+        valid_key = Fernet.generate_key()
+        assert validate_encryption_key(valid_key) is True
+
+    def test_validate_encryption_key_invalid(self):
+        """Test that an invalid key fails validation."""
+        invalid_keys = [
+            b"too_short",
+            b"this_is_not_a_valid_fernet_key_format",
+            b"",
+            b"123456789012345678901234567890XX",  # Wrong length/format
+        ]
+        for invalid_key in invalid_keys:
+            assert validate_encryption_key(invalid_key) is False
+
+    @patch("src.utils.encryption.get_settings")
+    def test_get_encryption_key_with_invalid_env_var(self, mock_get_settings):
+        """Test that an invalid ENCRYPTION_KEY environment variable causes exit."""
+        # Mock settings to return an invalid key
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = "invalid_key_format"
+        mock_get_settings.return_value = mock_settings
+
+        # Should exit with code 1
+        with pytest.raises(SystemExit) as exc_info:
+            # Clear the cache first
+            import src.utils.encryption
+            src.utils.encryption._cached_encryption_key = None
+            get_encryption_key()
+
+        assert exc_info.value.code == 1
+
+    @patch("src.utils.encryption.get_settings")
+    def test_get_encryption_key_with_valid_env_var(self, mock_get_settings):
+        """Test that a valid ENCRYPTION_KEY environment variable is accepted."""
+        # Mock settings to return a valid key
+        valid_key = Fernet.generate_key().decode()
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = valid_key
+        mock_get_settings.return_value = mock_settings
+
+        # Clear the cache first
+        import src.utils.encryption
+        src.utils.encryption._cached_encryption_key = None
+
+        # Should not raise an exception
+        key = get_encryption_key()
+        assert key == valid_key.encode()
+
+    @patch("src.utils.encryption.get_settings")
+    def test_get_encryption_key_auto_generate(self, mock_get_settings):
+        """Test that encryption key is auto-generated when not provided."""
+        # Mock settings with no encryption key
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = None
+        mock_get_settings.return_value = mock_settings
+
+        # Clear the cache first
+        import src.utils.encryption
+        src.utils.encryption._cached_encryption_key = None
+
+        # Should auto-generate a valid key
+        key = get_encryption_key()
+        assert key is not None
+        assert validate_encryption_key(key) is True
+
+
+class TestEncryptDecrypt:
+    """Test encryption and decryption functions."""
+
+    @patch("src.utils.encryption.get_settings")
+    def test_encrypt_decrypt_roundtrip(self, mock_get_settings):
+        """Test that values can be encrypted and decrypted."""
+        # Mock settings with no encryption key (will auto-generate)
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = None
+        mock_get_settings.return_value = mock_settings
+
+        # Clear the cache first
+        import src.utils.encryption
+        src.utils.encryption._cached_encryption_key = None
+
+        test_value = "secret_session_token_12345"
+        encrypted = encrypt_value(test_value)
+        assert encrypted != test_value
+        assert len(encrypted) > 0
+
+        decrypted = decrypt_value(encrypted)
+        assert decrypted == test_value
+
+    @patch("src.utils.encryption.get_settings")
+    def test_encrypt_empty_string(self, mock_get_settings):
+        """Test encrypting empty string."""
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = None
+        mock_get_settings.return_value = mock_settings
+
+        result = encrypt_value("")
+        assert result == ""
+
+    @patch("src.utils.encryption.get_settings")
+    def test_decrypt_empty_string(self, mock_get_settings):
+        """Test decrypting empty string."""
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = None
+        mock_get_settings.return_value = mock_settings
+
+        result = decrypt_value("")
+        assert result is None
+
+    @patch("src.utils.encryption.get_settings")
+    def test_decrypt_invalid_value(self, mock_get_settings):
+        """Test decrypting invalid encrypted value."""
+        mock_settings = MagicMock()
+        mock_settings.encryption_key = None
+        mock_get_settings.return_value = mock_settings
+
+        # Clear the cache first
+        import src.utils.encryption
+        src.utils.encryption._cached_encryption_key = None
+
+        result = decrypt_value("not_a_valid_encrypted_value")
+        assert result is None


### PR DESCRIPTION
## Summary
Adds startup validation for the `ENCRYPTION_KEY` environment variable to provide clear, actionable error messages when users configure an invalid encryption key.

## Problem
Users were encountering a cryptic error when setting an invalid `ENCRYPTION_KEY`:
```
Fernet key must be 32 url-safe base64-encoded bytes
```

This error provided no context about:
- Why the key was invalid
- How to fix it
- What format is required

## Solution
This PR adds validation at startup that:
- **Validates** `ENCRYPTION_KEY` format before attempting to use it
- **Provides clear error message** with detailed explanation
- **Offers two solutions**:
  1. Remove `ENCRYPTION_KEY` and let it auto-generate (recommended)
  2. Generate a valid key using: `python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
- **Exits immediately** with code 1 to prevent silent failures and confusing downstream errors

## Changes
- Added `validate_encryption_key()` function to check if a key is valid Fernet format
- Enhanced `get_encryption_key()` with validation and comprehensive error reporting
- Added comprehensive test suite (`tests/test_encryption.py`) covering:
  - Valid key acceptance
  - Invalid key rejection with proper exit code
  - Auto-generation when no key provided
  - Encrypt/decrypt roundtrip functionality
- Bumped version to 2.4.3

## Error Message Example
When an invalid key is detected, users now see:
```
================================================================================
INVALID ENCRYPTION_KEY DETECTED
================================================================================

The ENCRYPTION_KEY environment variable is set but is not a valid Fernet key.
A Fernet key must be 32 url-safe base64-encoded bytes.

To fix this issue, choose one of these options:

Option 1 (Recommended): Remove ENCRYPTION_KEY and let it auto-generate
  - Remove the ENCRYPTION_KEY from your docker-compose.yml or .env file
  - Restart the container

Option 2: Generate a valid Fernet key
  - Run: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
  - Set ENCRYPTION_KEY to the generated value

================================================================================
```

## Testing
- Added comprehensive test suite for encryption validation
- Tests cover valid/invalid keys, auto-generation, and encrypt/decrypt operations
- All existing functionality remains unchanged

## Impact
- **User Experience**: Clear, actionable error messages reduce support burden
- **Security**: Validation prevents using improperly formatted keys
- **Reliability**: Fail-fast approach prevents silent failures downstream

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>