### PR TITLE
Add update notification feature

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -5,6 +5,17 @@
 (No pending features at this time)
 
 ## Completed
+- [x] Update Notification Feature (2025-11-14)
+  - Added GitHub release checking API endpoint at `/api/check-update`
+  - Hourly rate limiting to prevent spamming GitHub API (1-hour cache)
+  - Orange "Update is available!" notification bubble next to version number in footer
+  - Uses Catppuccin Latte peach color (#fe640b) with hover effects
+  - Links directly to GitHub release notes page
+  - Frontend JavaScript checks for updates on page load
+  - Semantic version comparison (e.g., 2.5.0 > 2.4.4)
+  - Graceful error handling with console logging
+  - No new dependencies (uses existing httpx)
+  - All 94 tests passing
 - [x] Bridge Mode Detection - PR #51 (2025-11-01)
   - Automatically detects when Eero network is in bridge mode (DHCP/routing handled by upstream router)
   - Added migration 007: connection_mode field to network_metrics table

--- a/src/api/web.py
+++ b/src/api/web.py
@@ -1,10 +1,12 @@
 """Web UI routes for eeroVista."""
 
 import logging
-from typing import Any, Dict
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
@@ -13,6 +15,11 @@ from src.eero_client import EeroClientWrapper
 from src.utils.database import get_db
 
 logger = logging.getLogger(__name__)
+
+# Cache for version check
+_version_check_cache: Optional[Dict[str, Any]] = None
+_version_check_time: Optional[datetime] = None
+_VERSION_CHECK_INTERVAL = timedelta(hours=1)
 
 router = APIRouter(tags=["web"])
 templates = Jinja2Templates(directory="src/templates")
@@ -148,3 +155,91 @@ async def settings_page(
             "version": __version__,
         },
     )
+
+
+@router.get("/api/check-update")
+async def check_update():
+    """Check if a newer version is available on GitHub.
+
+    Returns:
+        JSON with update_available boolean, latest_version string, and release_url if available.
+        Uses hourly caching to avoid spamming GitHub API.
+    """
+    global _version_check_cache, _version_check_time
+
+    # Check if we have a cached result that's still valid
+    now = datetime.now()
+    if _version_check_cache and _version_check_time:
+        if now - _version_check_time < _VERSION_CHECK_INTERVAL:
+            return JSONResponse(_version_check_cache)
+
+    # Perform the check
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(
+                "https://api.github.com/repos/Yeraze/eeroVista/releases/latest",
+                headers={"Accept": "application/vnd.github.v3+json"}
+            )
+
+            if response.status_code == 200:
+                data = response.json()
+                latest_version = data.get("tag_name", "").lstrip("v")
+                release_url = data.get("html_url", "")
+
+                # Compare versions
+                current_version = __version__
+                update_available = _is_version_newer(latest_version, current_version)
+
+                result = {
+                    "update_available": update_available,
+                    "current_version": current_version,
+                    "latest_version": latest_version,
+                    "release_url": release_url,
+                }
+
+                # Cache the result
+                _version_check_cache = result
+                _version_check_time = now
+
+                return JSONResponse(result)
+            else:
+                logger.warning(f"Failed to check GitHub releases: {response.status_code}")
+                return JSONResponse({
+                    "update_available": False,
+                    "current_version": __version__,
+                    "error": "Failed to check for updates"
+                })
+
+    except Exception as e:
+        logger.error(f"Error checking for updates: {e}")
+        return JSONResponse({
+            "update_available": False,
+            "current_version": __version__,
+            "error": str(e)
+        })
+
+
+def _is_version_newer(latest: str, current: str) -> bool:
+    """Compare two semantic version strings.
+
+    Args:
+        latest: Latest version string (e.g., "2.5.0")
+        current: Current version string (e.g., "2.4.4")
+
+    Returns:
+        True if latest is newer than current
+    """
+    try:
+        latest_parts = [int(x) for x in latest.split(".")]
+        current_parts = [int(x) for x in current.split(".")]
+
+        # Pad with zeros if needed
+        while len(latest_parts) < 3:
+            latest_parts.append(0)
+        while len(current_parts) < 3:
+            current_parts.append(0)
+
+        return latest_parts > current_parts
+    except (ValueError, AttributeError):
+        # If we can't parse the versions, assume no update
+        return False

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -36,7 +36,14 @@
     </div>
 
     <footer style="text-align: center; padding: 2rem 0; margin-top: 4rem; color: var(--subtext1); font-size: 0.875rem; border-top: 1px solid var(--surface0);">
-        <p>eeroVista v{{ version }} &copy; 2025</p>
+        <p>
+            eeroVista v{{ version }} &copy; 2025
+            <span id="update-notification" style="display: none; margin-left: 0.5rem;">
+                <a href="#" id="update-link" target="_blank" style="display: inline-block; background-color: var(--peach); color: var(--base); padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.75rem; font-weight: 600; text-decoration: none; transition: opacity 0.2s;">
+                    Update is available!
+                </a>
+            </span>
+        </p>
         <p style="font-size: 0.75rem; margin-top: 0.5rem;">Read-only monitoring for Eero mesh networks</p>
     </footer>
 
@@ -51,6 +58,40 @@
             container.insertBefore(alertDiv, container.firstChild);
 
             setTimeout(() => alertDiv.remove(), 5000);
+        }
+
+        // Check for updates on page load
+        async function checkForUpdates() {
+            try {
+                const response = await fetch('/api/check-update');
+                const data = await response.json();
+
+                if (data.update_available && data.release_url) {
+                    const notification = document.getElementById('update-notification');
+                    const link = document.getElementById('update-link');
+
+                    link.href = data.release_url;
+                    link.title = `Version ${data.latest_version} is available`;
+                    notification.style.display = 'inline';
+
+                    // Add hover effect
+                    link.addEventListener('mouseenter', function() {
+                        this.style.opacity = '0.8';
+                    });
+                    link.addEventListener('mouseleave', function() {
+                        this.style.opacity = '1';
+                    });
+                }
+            } catch (error) {
+                console.error('Failed to check for updates:', error);
+            }
+        }
+
+        // Run update check on page load
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', checkForUpdates);
+        } else {
+            checkForUpdates();
         }
     </script>
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Summary
Adds an orange notification bubble next to the version number in the footer that alerts users when a new version is available on GitHub.

## Changes
- **Backend**: New `/api/check-update` endpoint with hourly rate limiting
  - Queries GitHub API for latest release
  - Compares semantic versions (e.g., 2.5.0 > 2.4.4)
  - Returns JSON with update status and release URL
  - 1-hour cache to prevent GitHub API spam
- **Frontend**: Update notification UI in `base.html`
  - Orange bubble using Catppuccin Latte peach color (#fe640b)
  - Links directly to GitHub release notes
  - JavaScript auto-check on page load
  - Hover effects for better UX
- **Documentation**: Updated TODOS.md

## Key Features
- ✅ Hourly rate limiting (prevents GitHub API abuse)
- ✅ Catppuccin Latte theme compliance
- ✅ Graceful error handling
- ✅ No new dependencies (uses existing httpx)
- ✅ Works on all pages (base template)

## Test Plan
- [x] All 94 tests passing
- [x] Semantic version comparison tested
- [x] Hourly cache mechanism implemented
- [x] UI displays correctly with Catppuccin peach color
- [x] Link opens to release notes page

🤖 Generated with [Claude Code](https://claude.com/claude-code)