### PR TITLE
Add TTL settings to dnsmasq configuration

### DIFF
--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -21,6 +21,12 @@ addn-hosts=/etc/dnsmasq.d/eerovista.hosts
 # Cache DNS queries
 cache-size=1000
 
+# TTL for hosts file responses (5 minutes = survives brief restarts)
+local-ttl=300
+
+# Limit negative cache TTL (1 minute = quick recovery if entry was missing)
+neg-ttl=60
+
 # Log queries for debugging (comment out in production)
 log-queries
 log-facility=/var/log/dnsmasq.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,12 @@ addn-hosts=/etc/dnsmasq.d/eerovista.hosts
 # Cache DNS queries
 cache-size=1000
 
+# TTL for hosts file responses (5 minutes = survives brief restarts)
+local-ttl=300
+
+# Limit negative cache TTL (1 minute = quick recovery if entry was missing)
+neg-ttl=60
+
 # Log queries for debugging (comment out in production)
 log-queries
 log-facility=/var/log/dnsmasq.log


### PR DESCRIPTION
## Summary
- Add `local-ttl=300` for hosts file responses (5 minutes)
- Add `neg-ttl=60` to limit NXDOMAIN caching (1 minute)

## Why
Downstream DNS servers (like AdGuard) can cache NXDOMAIN responses if eeroVista is briefly unavailable. These settings help:
- **local-ttl=300**: Downstream servers cache valid responses for 5 minutes, surviving brief restarts
- **neg-ttl=60**: If a negative response is returned, it expires quickly (1 minute) for fast recovery

## Test plan
- [ ] Deploy and verify TTL values in DNS responses using `dig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)