### PR TITLE
Fix Settings page showing hardcoded version

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,8 @@ from zoneinfo import ZoneInfo
 
 from pydantic_settings import BaseSettings
 
+from src import __version__
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,7 +18,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "eeroVista"
-    version: str = "0.9.0"
+    version: str = __version__
     debug: bool = False
 
     # Database


### PR DESCRIPTION
## Summary
- Fix Settings page showing hardcoded 0.9.0 version instead of actual version
- Use `__version__` from `src/__init__.py` as the single source of truth

## Test plan
- [x] Unit tests pass locally
- [ ] Verify Settings page displays correct version (2.4.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)