### PR TITLE
fix(prometheus): restore missing speedtest and bandwidth metrics

### DIFF
--- a/src/api/prometheus.py
+++ b/src/api/prometheus.py
@@ -316,26 +316,24 @@ def update_metrics() -> None:
                                 node=node_name
                             ).set(latest_conn.signal_strength)
 
-                        # Current bandwidth
-                        if latest_conn.bandwidth_down_mbps is not None:
-                            device_bandwidth_down_mbps.labels(
-                                network=device.network_name,
-                                mac=mac,
-                                hostname=hostname,
-                                nickname=nickname,
-                                type=device_type,
-                                node=node_name
-                            ).set(latest_conn.bandwidth_down_mbps)
+                        # Current bandwidth - always emit (0 when not available from API)
+                        device_bandwidth_down_mbps.labels(
+                            network=device.network_name,
+                            mac=mac,
+                            hostname=hostname,
+                            nickname=nickname,
+                            type=device_type,
+                            node=node_name
+                        ).set(latest_conn.bandwidth_down_mbps if latest_conn.bandwidth_down_mbps is not None else 0.0)
 
-                        if latest_conn.bandwidth_up_mbps is not None:
-                            device_bandwidth_up_mbps.labels(
-                                network=device.network_name,
-                                mac=mac,
-                                hostname=hostname,
-                                nickname=nickname,
-                                type=device_type,
-                                node=node_name
-                            ).set(latest_conn.bandwidth_up_mbps)
+                        device_bandwidth_up_mbps.labels(
+                            network=device.network_name,
+                            mac=mac,
+                            hostname=hostname,
+                            nickname=nickname,
+                            type=device_type,
+                            node=node_name
+                        ).set(latest_conn.bandwidth_up_mbps if latest_conn.bandwidth_up_mbps is not None else 0.0)
 
                     # Get daily bandwidth using pre-fetched data
                     daily_bw = bandwidth_by_device.get(device.id)


### PR DESCRIPTION
After adding the `network` label to all metrics, two categories of metrics stopped producing data lines (showing only `# HELP`/`# TYPE` headers with no samples):

- `eero_speedtest_*` — speedtest collector silently failed to store data
- `eero_device_bandwidth_*` — metrics disappeared when Eero API had no current bandwidth data

**Speedtest collector fix** (`src/collectors/speedtest_collector.py`): The `eero_patch.py` fallback can return a raw dict instead of a Pydantic model when validation fails. The collector assumed Pydantic attribute access (`.down.value`), which raised `AttributeError` on dicts — caught silently at debug level, leaving the DB empty and metrics invisible. The collector now detects the dict/model type and extracts values accordingly. Latency is now also extracted from the raw dict when present. Exception logging is upgraded from debug to warning for visibility.

**Bandwidth metrics fix** (`src/api/prometheus.py`): Prometheus labeled Gauges only emit samples for label combinations that have been explicitly set — unlike unlabeled Gauges which default to 0. Device bandwidth is periodically populated by the Eero API, so `bandwidth_down/up_mbps` are often `None` in `DeviceConnection` records. The `if ... is not None` guards have been removed; metrics now always emit with a 0.0 fallback, keeping them visible in Prometheus/Grafana.