### PR TITLE
fix: make eero_patch effective for Account validation (#114)

### DIFF
--- a/src/utils/eero_patch.py
+++ b/src/utils/eero_patch.py
@@ -36,7 +36,7 @@ def patch_pydantic_models():
     """
     try:
         print(f"[PATCH v{__version__}] Importing eero-client Pydantic models...")
-        from eero.client.models import NetworkInfo
+        from eero.client.models import Account, NetworkInfo
         from eero.client.models.account import PremiumDetails
         from pydantic.fields import FieldInfo
 
@@ -73,9 +73,12 @@ def patch_pydantic_models():
                     )
                 logger.debug("Patched PremiumDetails.interval to Optional[str]")
 
-        # Rebuild the models with updated annotations - force full rebuild
+        # Rebuild the models with updated annotations - force full rebuild.
+        # Account must also be rebuilt because it embeds NetworkInfo/PremiumDetails;
+        # its compiled validator still references the original str-only schemas otherwise.
         NetworkInfo.model_rebuild(force=True)
         PremiumDetails.model_rebuild(force=True)
+        Account.model_rebuild(force=True)
 
         print(f"[PATCH v{__version__}] ✓ Pydantic model patches applied successfully")
         logger.info("Pydantic model patches applied successfully")
@@ -141,8 +144,16 @@ def patch_eero_client():
 
             return lambda self, **caller_kwargs: func(self, **kwargs, **caller_kwargs)
 
-        # Apply the patch
+        # Apply the patch. Must patch both the source module AND every importer
+        # that did `from ..routes.method_factory import make_method`, because
+        # those have their own local name binding to the original function.
         method_factory.make_method = patched_make_method
+
+        try:
+            import eero.client.clients.eero as eero_module
+            eero_module.make_method = patched_make_method
+        except ImportError as e:
+            logger.warning(f"Could not patch eero.client.clients.eero.make_method: {e}")
 
         print(f"[PATCH v{__version__}] ✓ eero-client patch applied successfully")
         logger.info("eero-client patch applied successfully")

--- a/tests/test_eero_patch.py
+++ b/tests/test_eero_patch.py
@@ -125,6 +125,26 @@ class TestPatchedMakeMethod:
         assert "net_123" in call_args[0][1]
 
 
+class TestPatchCoversAccountAndEeroModule:
+    """Regression tests for issue #114."""
+
+    def test_account_model_is_rebuilt(self):
+        """Account must be rebuilt so its compiled validator picks up
+        the Optional[str] patches on nested NetworkInfo / PremiumDetails."""
+        from eero.client.models import Account
+
+        assert getattr(Account, "__pydantic_complete__", False) is True
+
+    def test_eero_clients_module_make_method_is_patched(self):
+        """`from ..routes.method_factory import make_method` in
+        eero.client.clients.eero creates a local binding that must also
+        be replaced; otherwise Eero.account keeps using the unpatched function."""
+        from eero.client.routes import method_factory
+        import eero.client.clients.eero as eero_module
+
+        assert eero_module.make_method is method_factory.make_method
+
+
 class TestModuleLevelPatches:
     """Tests that the module-level patches ran correctly at import time."""
 


### PR DESCRIPTION
## Summary
- Add `Account.model_rebuild(force=True)` so the compiled Account validator picks up the `Optional[str]` patches applied to nested `NetworkInfo.amazon_directed_id` and `PremiumDetails.interval`.
- Also rebind `make_method` on `eero.client.clients.eero` — that module imports it as a local name, so patching only `method_factory.make_method` left `Eero.account` using the original function.
- Adds regression tests for both fixes.

Fixes #114.

## Test plan
- [x] `pytest tests/test_eero_patch.py` — 15 passed
- [x] Full suite `pytest` — 829 passed
- [ ] Verify in deployment: no `ValidationError` spam in logs on Amazon-linked / shared-admin accounts; devices return as Pydantic models, not raw dicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)