### PR TITLE
chore: bump version to 2.7.1

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.7.0"
+__version__ = "2.7.1"


### PR DESCRIPTION
## Summary
Patch release rolling up the eero_patch effectiveness fix merged via #115 (fixes #114).

## Test plan
- [x] Local pytest suite green (829 passed)
- [x] Verified live in dev container post-authentication: no more `Failed to Marshal` / `Failed to validate account` / Account `ValidationError` spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)