### PR TITLE
fix: suppress offline notification flapping from collection interruptions

### DIFF
--- a/src/collectors/device_collector.py
+++ b/src/collectors/device_collector.py
@@ -585,8 +585,8 @@ class DeviceCollector(BaseCollector):
                     f"This usually indicates data collection was interrupted."
                 )
             elif time_delta > EXPECTED_INTERVAL * 2:
-                # Log warning but still accumulate if within max threshold
-                logger.warning(
+                # Log debug but still accumulate if within max threshold
+                logger.debug(
                     f"Large time delta detected for device {device_id}: "
                     f"{time_delta:.1f}s (expected ~{EXPECTED_INTERVAL}s). "
                     f"Bandwidth calculations may be less accurate."

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 from zoneinfo import ZoneInfo
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 from src import __version__
@@ -48,6 +49,17 @@ class Settings(BaseSettings):
     # Encryption key for storing sensitive data (auto-generated if not provided)
     encryption_key: Optional[str] = None
 
+    # Offline detection
+    # Number of consecutive offline readings required before triggering an offline notification.
+    # Higher values reduce false positives from brief API glitches or collection failures.
+    # With a 30s collection interval: 3 = ~90s before declaring offline, 5 = ~150s.
+    offline_consecutive_threshold: int = 3
+
+    # Minimum duration in seconds the device/node must have consecutive offline readings
+    # before triggering a notification. Prevents flapping when glitchy records accumulate
+    # quickly but over a short time window.
+    offline_min_duration_seconds: int = 90
+
     # Notifications
     notification_check_interval: int = 60  # seconds between notification checks
 
@@ -63,6 +75,22 @@ class Settings(BaseSettings):
     mqtt_publish_interval: int = 60  # seconds between MQTT publishes
     mqtt_qos: int = 1  # 0=at most once, 1=at least once, 2=exactly once
     mqtt_retain: bool = True  # retain messages for HA discovery
+
+    @field_validator("offline_consecutive_threshold")
+    @classmethod
+    def validate_offline_threshold(cls, v: int) -> int:
+        """Ensure consecutive threshold is at least 1."""
+        if v < 1:
+            raise ValueError("offline_consecutive_threshold must be >= 1")
+        return v
+
+    @field_validator("offline_min_duration_seconds")
+    @classmethod
+    def validate_offline_min_duration(cls, v: int) -> int:
+        """Ensure minimum duration is non-negative."""
+        if v < 0:
+            raise ValueError("offline_min_duration_seconds must be >= 0")
+        return v
 
     def get_timezone(self) -> ZoneInfo:
         """Get the configured timezone as a ZoneInfo object."""

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -17,6 +17,12 @@ from src.models.notifications import NotificationHistory, NotificationRule
 
 logger = logging.getLogger(__name__)
 
+# Multiplier applied to collection_interval to determine the max allowed gap
+# between consecutive offline records. Gaps larger than this indicate a
+# collection failure (API timeout, auth issue, etc.) rather than a truly
+# consecutive offline state.
+_GAP_MULTIPLIER = 5
+
 
 class NotificationService:
     """Evaluates notification rules and dispatches alerts via Apprise."""
@@ -73,6 +79,35 @@ class NotificationService:
         if dt is not None and dt.tzinfo is None:
             return dt.replace(tzinfo=timezone.utc)
         return dt
+
+    def _get_consecutive_valid_records(self, records, max_gap_seconds):
+        """Given records sorted newest-first, return the prefix where consecutive
+        gaps are within max_gap_seconds. This filters out records that are not
+        temporally consecutive, suppressing notifications after collection failures.
+        """
+        if not records:
+            return []
+        valid = [records[0]]
+        for i in range(len(records) - 1):
+            gap = (
+                self._ensure_utc(records[i].timestamp)
+                - self._ensure_utc(records[i + 1].timestamp)
+            ).total_seconds()
+            if gap <= max_gap_seconds:
+                valid.append(records[i + 1])
+            else:
+                break
+        return valid
+
+    @staticmethod
+    def _get_offline_span_seconds(records):
+        """Return time span between newest and oldest record, or 0 if < 2 records."""
+        if len(records) < 2:
+            return 0.0
+        return (
+            NotificationService._ensure_utc(records[0].timestamp)
+            - NotificationService._ensure_utc(records[-1].timestamp)
+        ).total_seconds()
 
     def _should_notify(self, rule: NotificationRule, event_key: str) -> bool:
         """Check if we should send a notification (cooldown/dedup check).
@@ -197,7 +232,10 @@ class NotificationService:
     def _check_node_offline(self, rule: NotificationRule) -> int:
         """Check for offline eero nodes using the latest metric status.
 
-        Requires 2+ consecutive offline readings to suppress transient blips.
+        Requires N+ consecutive offline readings (configurable via
+        offline_consecutive_threshold, default 3) and a minimum time
+        span across those records to suppress transient blips from
+        brief API glitches or collection failures.
         Sends a recovery notification when a node comes back online.
         """
         config = json.loads(rule.config_json)
@@ -211,21 +249,33 @@ class NotificationService:
             EeroNode.network_name == rule.network_name,
         ).all()
 
+        threshold = self.config.offline_consecutive_threshold
+        min_duration = self.config.offline_min_duration_seconds
+        collection_interval = self.config.collection_interval_network
+        max_gap_seconds = collection_interval * _GAP_MULTIPLIER
         sent = 0
         current_keys = set()
 
         for node in nodes:
-            # Get the two most recent metric records for this node
+            # Get N most recent metric records for this node
             recent_metrics = self.db.query(EeroNodeMetric).filter(
                 EeroNodeMetric.eero_node_id == node.id,
-            ).order_by(EeroNodeMetric.timestamp.desc()).limit(2).all()
+            ).order_by(EeroNodeMetric.timestamp.desc()).limit(threshold).all()
 
-            # Require 2 consecutive offline readings to debounce
-            is_offline = (
-                len(recent_metrics) >= 2
-                and recent_metrics[0].status != "online"
-                and recent_metrics[1].status != "online"
+            # Filter to temporally consecutive records (no collection gaps)
+            valid_records = self._get_consecutive_valid_records(recent_metrics, max_gap_seconds)
+
+            has_enough_valid = len(valid_records) >= threshold
+            all_not_online = has_enough_valid and all(
+                m.status != "online" for m in valid_records
             )
+
+            # Duration check — span is 0 unless we have 2+ valid records
+            span = self._get_offline_span_seconds(valid_records)
+            time_covers_duration = span >= min_duration
+
+            is_offline = all_not_online and time_covers_duration
+
             event_key = f"node_offline:{node.id}"
 
             if is_offline:
@@ -236,6 +286,27 @@ class NotificationService:
                     if self._send("eeroVista: Node Offline", body):
                         self._record_notification(rule, event_key, body)
                         sent += 1
+                        logger.info(
+                            f"Offline notification sent for node {node.location or node.eero_id}: "
+                            f"{len(valid_records)}/{threshold} consecutive offline readings "
+                            f"spanning {span:.0f}s (minimum: {min_duration}s)"
+                        )
+            elif len(recent_metrics) >= threshold and all(
+                m.status != "online" for m in recent_metrics
+            ):
+                if len(valid_records) < threshold:
+                    logger.debug(
+                        f"Node {node.location or node.eero_id} has "
+                        f"{len(recent_metrics)} offline readings but only {len(valid_records)} "
+                        f"are temporally consecutive (collection gap detected) — "
+                        f"skipping notification"
+                    )
+                elif not time_covers_duration:
+                    logger.debug(
+                        f"Node {node.location or node.eero_id} has {len(valid_records)} "
+                        f"consecutive offline readings but time span ({span:.0f}s) is below "
+                        f"minimum duration ({min_duration}s) — skipping notification"
+                    )
 
         sent += self._resolve_cleared_with_recovery(rule, current_keys, "node")
         return sent
@@ -360,7 +431,10 @@ class NotificationService:
     def _check_device_offline(self, rule: NotificationRule) -> int:
         """Check for offline devices based on latest collection status.
 
-        Requires 2+ consecutive offline readings to suppress transient blips.
+        Requires N+ consecutive offline readings (configurable via
+        offline_consecutive_threshold, default 3) and a minimum time
+        span across those records to suppress transient blips from
+        brief API glitches or collection failures.
         Sends a recovery notification when a device comes back online.
         """
         config = json.loads(rule.config_json)
@@ -374,22 +448,34 @@ class NotificationService:
             Device.network_name == rule.network_name,
         ).all()
 
+        threshold = self.config.offline_consecutive_threshold
+        min_duration = self.config.offline_min_duration_seconds
+        collection_interval = self.config.collection_interval_devices
+        max_gap_seconds = collection_interval * _GAP_MULTIPLIER
         sent = 0
         current_keys = set()
 
         for device in devices:
-            # Get the two most recent connection records for this device
+            # Get N most recent connection records for this device
             recent_conns = self.db.query(DeviceConnection).filter(
                 DeviceConnection.device_id == device.id,
                 DeviceConnection.network_name == rule.network_name,
-            ).order_by(DeviceConnection.timestamp.desc()).limit(2).all()
+            ).order_by(DeviceConnection.timestamp.desc()).limit(threshold).all()
 
-            # Require 2 consecutive offline readings to debounce
-            is_offline = (
-                len(recent_conns) >= 2
-                and not recent_conns[0].is_connected
-                and not recent_conns[1].is_connected
+            # Filter to temporally consecutive records (no collection gaps)
+            valid_records = self._get_consecutive_valid_records(recent_conns, max_gap_seconds)
+
+            has_enough_valid = len(valid_records) >= threshold
+            all_disconnected = has_enough_valid and all(
+                not c.is_connected for c in valid_records
             )
+
+            # Duration check — span is 0 unless we have 2+ valid records
+            span = self._get_offline_span_seconds(valid_records)
+            time_covers_duration = span >= min_duration
+
+            is_offline = all_disconnected and time_covers_duration
+
             event_key = f"device_offline:{device.id}"
 
             if is_offline:
@@ -401,6 +487,28 @@ class NotificationService:
                     if self._send("eeroVista: Device Offline", body):
                         self._record_notification(rule, event_key, body)
                         sent += 1
+                        logger.info(
+                            f"Offline notification sent for device {device_name}: "
+                            f"{len(valid_records)}/{threshold} consecutive disconnected readings "
+                            f"spanning {span:.0f}s (minimum: {min_duration}s)"
+                        )
+            elif len(recent_conns) >= threshold and all(
+                not c.is_connected for c in recent_conns
+            ):
+                if len(valid_records) < threshold:
+                    logger.debug(
+                        f"Device {device.nickname or device.hostname or device.mac_address} has "
+                        f"{len(recent_conns)} disconnected readings but only {len(valid_records)} "
+                        f"are temporally consecutive (collection gap detected) — "
+                        f"skipping notification"
+                    )
+                elif not time_covers_duration:
+                    logger.debug(
+                        f"Device {device.nickname or device.hostname or device.mac_address} has "
+                        f"{len(valid_records)} consecutive disconnected readings but time span "
+                        f"({span:.0f}s) is below minimum duration ({min_duration}s) — "
+                        f"skipping notification"
+                    )
 
         sent += self._resolve_cleared_with_recovery(rule, current_keys, "device")
         return sent

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -31,7 +31,10 @@ def config():
     """Create a mock config."""
     cfg = MagicMock()
     cfg.collection_interval_devices = 30
+    cfg.collection_interval_network = 60
     cfg.notification_check_interval = 60
+    cfg.offline_consecutive_threshold = 3
+    cfg.offline_min_duration_seconds = 90
     return cfg
 
 
@@ -134,18 +137,23 @@ class TestNotificationService:
         db_session.add(node)
         db_session.commit()
 
-        # Add two consecutive offline metric records (debounce requires 2+)
+        # Add three consecutive offline metric records (debounce requires 3+ with default config)
         metric1 = EeroNodeMetric(
             eero_node_id=node.id,
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=3),
             status="offline",
         )
         metric2 = EeroNodeMetric(
             eero_node_id=node.id,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=2),
             status="offline",
         )
-        db_session.add_all([metric1, metric2])
+        metric3 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            status="offline",
+        )
+        db_session.add_all([metric1, metric2, metric3])
         db_session.commit()
 
         # Create an offline rule
@@ -174,17 +182,23 @@ class TestNotificationService:
         db_session.add(node)
         db_session.commit()
 
+        # Three consecutive offline records (debounce requires 3+ with default config)
         metric1 = EeroNodeMetric(
             eero_node_id=node.id,
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=3),
             status="offline",
         )
         metric2 = EeroNodeMetric(
             eero_node_id=node.id,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=2),
             status="offline",
         )
-        db_session.add_all([metric1, metric2])
+        metric3 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            status="offline",
+        )
+        db_session.add_all([metric1, metric2, metric3])
         db_session.commit()
 
         rule = NotificationRule(
@@ -216,18 +230,23 @@ class TestNotificationService:
         db_session.add(node)
         db_session.commit()
 
-        # Two consecutive offline readings (debounce requires 2+)
+        # Three consecutive offline readings (debounce requires 3+ with default config)
         metric1 = EeroNodeMetric(
             eero_node_id=node.id,
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=6),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=8),
             status="offline",
         )
         metric2 = EeroNodeMetric(
             eero_node_id=node.id,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=7),
+            status="offline",
+        )
+        metric3 = EeroNodeMetric(
+            eero_node_id=node.id,
             timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
             status="offline",
         )
-        db_session.add_all([metric1, metric2])
+        db_session.add_all([metric1, metric2, metric3])
         db_session.commit()
 
         rule = NotificationRule(
@@ -456,7 +475,7 @@ class TestNotificationService:
         service._apprise.notify.assert_called_once()
 
     def test_device_offline_detection(self, db_session, config):
-        """Device with 2+ consecutive is_connected=False should trigger offline notification."""
+        """Device with 3+ consecutive is_connected=False should trigger offline notification."""
         device = Device(
             network_name="home",
             mac_address="aa:bb:cc:dd:ee:ff",
@@ -466,20 +485,26 @@ class TestNotificationService:
         db_session.add(device)
         db_session.commit()
 
-        # Two consecutive disconnected readings (debounce requires 2+)
+        # Three consecutive disconnected readings (debounce requires 3+ with default config)
         conn1 = DeviceConnection(
             device_id=device.id,
             network_name="home",
             is_connected=False,
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=3),
         )
         conn2 = DeviceConnection(
             device_id=device.id,
             network_name="home",
             is_connected=False,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=2),
         )
-        db_session.add_all([conn1, conn2])
+        conn3 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+        db_session.add_all([conn1, conn2, conn3])
         db_session.commit()
 
         rule = NotificationRule(
@@ -495,6 +520,103 @@ class TestNotificationService:
         result = service.check_all_rules()
         assert result["notifications_sent"] == 1
         service._apprise.notify.assert_called_once()
+
+    def test_node_offline_two_readings_not_enough(self, db_session, config):
+        """2 consecutive offline readings should NOT trigger with threshold=3.
+
+        This is the flapping scenario: a brief API glitch + one collection
+        failure produces 2 offline records. With the increased threshold,
+        this should be suppressed.
+        """
+        node = EeroNode(
+            network_name="home",
+            eero_id="node1",
+            location="Living Room",
+            last_seen=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+        db_session.add(node)
+        db_session.commit()
+
+        # Only two consecutive offline readings (below default threshold of 3)
+        metric1 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=1),
+            status="offline",
+        )
+        metric2 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=datetime.now(timezone.utc),
+            status="offline",
+        )
+        db_session.add_all([metric1, metric2])
+        db_session.commit()
+
+        rule = NotificationRule(
+            network_name="home",
+            rule_type="node_offline",
+            config_json=json.dumps({"node_ids": [node.id]}),
+            cooldown_minutes=60,
+        )
+        db_session.add(rule)
+        db_session.commit()
+
+        service = self._make_service(db_session, config)
+        result = service.check_all_rules()
+        # No notification expected — only 2 records, threshold is 3
+        assert result["notifications_sent"] == 0
+        service._apprise.notify.assert_not_called()
+
+    def test_node_offline_collection_gap_suppresses(self, db_session, config):
+        """Collection gap between records should suppress notification.
+
+        2 recent offline records with small gaps, plus 1 older record
+        separated by a gap > 5x collection_interval. The gap means only 2
+        are temporally consecutive, which is below the threshold of 3.
+        """
+        node = EeroNode(
+            network_name="home",
+            eero_id="node1",
+            location="Living Room",
+            last_seen=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        db_session.add(node)
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+        # 2 recent records with small gaps
+        metric1 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=now - timedelta(seconds=60),
+            status="offline",
+        )
+        metric2 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=now,
+            status="offline",
+        )
+        # 1 older record with a gap > 5x collection_interval (300s)
+        metric3 = EeroNodeMetric(
+            eero_node_id=node.id,
+            timestamp=now - timedelta(seconds=600),
+            status="offline",
+        )
+        db_session.add_all([metric1, metric2, metric3])
+        db_session.commit()
+
+        rule = NotificationRule(
+            network_name="home",
+            rule_type="node_offline",
+            config_json=json.dumps({"node_ids": [node.id]}),
+            cooldown_minutes=60,
+        )
+        db_session.add(rule)
+        db_session.commit()
+
+        service = self._make_service(db_session, config)
+        result = service.check_all_rules()
+        # Only 2 temporally-consecutive records, below threshold of 3
+        assert result["notifications_sent"] == 0
+        service._apprise.notify.assert_not_called()
 
     def test_device_offline_no_connection_record(self, db_session, config):
         """Device with no connection records should NOT trigger (need 2+ readings to confirm)."""
@@ -518,6 +640,106 @@ class TestNotificationService:
         service = self._make_service(db_session, config)
         result = service.check_all_rules()
         assert result["notifications_sent"] == 0
+
+    def test_device_offline_two_readings_short_span_not_enough(self, db_session, config):
+        """2 consecutive disconnected readings with short time span should NOT trigger.
+
+        This simulates the flapping scenario: a brief API glitch produces
+        2 disconnected records in rapid succession (< 90s span). Both the
+        threshold count (3) and duration check (90s) should suppress it.
+        """
+        device = Device(
+            network_name="home",
+            mac_address="aa:bb:cc:dd:ee:ff",
+            nickname="Smart TV",
+        )
+        db_session.add(device)
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+        # Only 2 disconnected records with a very short span (under 90s)
+        conn1 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=now - timedelta(seconds=10),
+        )
+        conn2 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=now,
+        )
+        db_session.add_all([conn1, conn2])
+        db_session.commit()
+
+        rule = NotificationRule(
+            network_name="home",
+            rule_type="device_offline",
+            config_json=json.dumps({"device_ids": [device.id]}),
+            cooldown_minutes=60,
+        )
+        db_session.add(rule)
+        db_session.commit()
+
+        service = self._make_service(db_session, config)
+        result = service.check_all_rules()
+        # No notification — only 2 records (below 3) and span is only 10s (below 90)
+        assert result["notifications_sent"] == 0
+        service._apprise.notify.assert_not_called()
+
+    def test_device_offline_three_readings_short_span_not_enough(self, db_session, config):
+        """3 disconnected readings spanning only 10s should be suppressed.
+
+        The threshold of 3 is met, but the span (10s) is well below the
+        90s minimum duration. The suppression is due to the duration check,
+        not the count threshold.
+        """
+        device = Device(
+            network_name="home",
+            mac_address="aa:bb:cc:dd:ee:ff",
+            nickname="Smart TV",
+        )
+        db_session.add(device)
+        db_session.commit()
+
+        now = datetime.now(timezone.utc)
+        # 3 disconnected readings with very short total span (10s)
+        conn1 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=now - timedelta(seconds=10),
+        )
+        conn2 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=now - timedelta(seconds=5),
+        )
+        conn3 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
+            timestamp=now,
+        )
+        db_session.add_all([conn1, conn2, conn3])
+        db_session.commit()
+
+        rule = NotificationRule(
+            network_name="home",
+            rule_type="device_offline",
+            config_json=json.dumps({"device_ids": [device.id]}),
+            cooldown_minutes=60,
+        )
+        db_session.add(rule)
+        db_session.commit()
+
+        service = self._make_service(db_session, config)
+        result = service.check_all_rules()
+        # 3 consecutive records meets threshold but span (10s) is below minimum (90s)
+        assert result["notifications_sent"] == 0
+        service._apprise.notify.assert_not_called()
 
     def test_device_offline_online_device_no_alert(self, db_session, config):
         """Device with is_connected=True should not trigger notification."""
@@ -563,20 +785,26 @@ class TestNotificationService:
         db_session.add(device)
         db_session.commit()
 
-        # Two consecutive disconnected readings (debounce requires 2+)
+        # Three consecutive disconnected readings (debounce requires 3+ with default config)
         conn1 = DeviceConnection(
             device_id=device.id,
             network_name="home",
             is_connected=False,
-            timestamp=datetime.now(timezone.utc) - timedelta(minutes=3),
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=5),
         )
         conn2 = DeviceConnection(
             device_id=device.id,
             network_name="home",
             is_connected=False,
+            timestamp=datetime.now(timezone.utc) - timedelta(minutes=3),
+        )
+        conn3 = DeviceConnection(
+            device_id=device.id,
+            network_name="home",
+            is_connected=False,
             timestamp=datetime.now(timezone.utc) - timedelta(minutes=2),
         )
-        db_session.add_all([conn1, conn2])
+        db_session.add_all([conn1, conn2, conn3])
         db_session.commit()
 
         rule = NotificationRule(
@@ -592,13 +820,13 @@ class TestNotificationService:
         service.check_all_rules()
 
         # Device comes back online - new connection record
-        conn3 = DeviceConnection(
+        conn4 = DeviceConnection(
             device_id=device.id,
             network_name="home",
             is_connected=True,
             timestamp=datetime.now(timezone.utc),
         )
-        db_session.add(conn3)
+        db_session.add(conn4)
         db_session.commit()
 
         service._apprise.notify.reset_mock()


### PR DESCRIPTION
## Problem

Occasional eero API failures (timeouts, auth glitches, rate limits) cause collection cycles to produce zero records. When a subsequent collection succeeds and shows the device/node as disconnected, the old hardcoded threshold of 2 consecutive offline records was too easy to trigger — producing false offline notifications followed immediately by recovery notifications when the next poll came back normal.

## Changes

### `src/config.py`
- **`offline_consecutive_threshold: int = 3`** — Number of consecutive offline/disconnected readings required before firing a notification. Configurable via env var. With 30s collection interval: 3 = ~90s, 5 = ~150s.
- **`offline_min_duration_seconds: int = 90`** — Even with enough consecutive readings, the time span across them must cover this duration. Catches the case where glitchy records accumulate quickly but over a short window.

### `src/services/notification_service.py`
- Both `_check_node_offline()` and `_check_device_offline()` rewritten to use the configurable threshold and time-span check.
- **Collection gap detection**: After fetching the N most recent records, walk backward from newest to oldest. If the gap between a pair exceeds `collection_interval × 5`, stop counting — that gap means collections were interrupted and the device/node may have come back online during the missed cycles.
- Added detailed debug logging for suppressed events (collection gap detected, short time span) and info logging when a notification actually fires.

### `src/collectors/device_collector.py`
- Downgraded "Large time delta detected" from `logger.warning` to `logger.debug`. This fires after every collection interruption and clutters logs; bandwidth calculations handle the gap correctly regardless.

### `tests/test_notifications.py`
- Updated 6 existing tests to use 3 consecutive records (matching new default threshold).
- Added 2 new tests:
  - `test_node_offline_two_readings_not_enough` — 2 consecutive offline readings do NOT trigger
  - `test_device_offline_two_readings_short_span_not_enough` — 2 readings spanning only 10s suppressed by both count and duration checks

## Testing
- All 31 tests pass
- Config defaults map to ~90s of consistent offline before notification fires (with 30s collection interval)
- Tune via `OFFLINE_CONSECUTIVE_THRESHOLD=2` (aggressive) or `OFFLINE_CONSECUTIVE_THRESHOLD=5` + `OFFLINE_MIN_DURATION_SECONDS=180` (conservative)