### PR TITLE
feat: read-only MCP server for AI agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ env/
 *.swo
 *~
 
+# Serena MCP
+.serena/
+
 # Testing
 .pytest_cache/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **MCP server for AI agents**: New optional [Model Context Protocol](docs/mcp.md) server exposing a curated set of 12 read-only tools (network summary, device/node lists, health score, WAN uptime, outages, speedtests, signal quality, top bandwidth users, and more) over Streamable HTTP. Mounted on the existing web server at a configurable path (`MCP_PATH`, default `/mcp`) and disabled by default (`MCP_ENABLED`). The tools reuse the existing REST query logic, so output matches the API. The endpoint has no authentication — expose only behind a trusted reverse proxy.
+
 ## [2.7.2] — 2026-05-26
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,12 @@ services:
       # - MQTT_TOPIC_PREFIX=eerovista
       # - MQTT_DISCOVERY_PREFIX=homeassistant
       # - MQTT_PUBLISH_INTERVAL=60
+
+      # MCP server for AI agents (disabled by default)
+      # NOTE: the /mcp endpoint has NO authentication - only enable behind a
+      # trusted reverse proxy or on a network you control. See docs/mcp.md.
+      # - MCP_ENABLED=true
+      # - MCP_PATH=/mcp
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
       interval: 30s

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ A read-only web-based monitoring tool for Eero mesh networks.
 - [Configuration Reference](configuration.md)
 - [API Documentation](api-reference.md)
 - [Reverse Proxy & HTTPS](reverse-proxy.md)
+- [MCP Server (AI Agents)](mcp.md)
 - [Prometheus Integration](prometheus.md)
 - [Zabbix Integration](zabbix.md)
 - [Development Guide](development.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,92 @@
+---
+layout: default
+title: MCP Server (AI Agents)
+nav_order: 7
+---
+
+# MCP Server (AI Agents)
+
+eeroVista can expose a **Model Context Protocol (MCP)** server so that AI agents
+(such as Claude) can query your eero network status in real time using a curated
+set of read-only tools. The tools reuse eeroVista's existing query logic, so they
+return the same data as the REST API — just packaged for agent consumption.
+
+Like the rest of eeroVista, the MCP server is **strictly read-only**. None of the
+tools can change your network configuration.
+
+## ⚠️ Security
+
+The MCP endpoint has **no authentication**. Only enable it when eeroVista is on a
+network you control or behind a trusted reverse proxy that restricts access. Do
+not expose the `/mcp` path directly to the public internet.
+
+See [Reverse Proxy & HTTPS](reverse-proxy.md) for how to put eeroVista (and the
+MCP endpoint) behind nginx/Caddy with TLS and access controls.
+
+## Configuration
+
+The MCP server is **disabled by default**. Enable it with environment variables in
+your `docker-compose.yml`:
+
+```yaml
+environment:
+  - MCP_ENABLED=true     # Enable the MCP server (default: false)
+  - MCP_PATH=/mcp        # Path the MCP endpoint is mounted at (default: /mcp)
+```
+
+When enabled, the server is mounted on the existing eeroVista web server — same
+host and port (default `8080`) — using the **Streamable HTTP** transport. With the
+defaults above, the endpoint is:
+
+```
+http://<your-host>:8080/mcp
+```
+
+## Connecting an agent
+
+Point any MCP client that supports the Streamable HTTP transport at the endpoint
+URL. For example, with the Claude Code CLI:
+
+```bash
+claude mcp add --transport http eerovista http://<your-host>:8080/mcp
+```
+
+Or in an MCP client configuration file:
+
+```json
+{
+  "mcpServers": {
+    "eerovista": {
+      "transport": "http",
+      "url": "http://<your-host>:8080/mcp"
+    }
+  }
+}
+```
+
+## Available tools
+
+All tools accept an optional `network` argument (the network name); omit it to use
+the default (first) network.
+
+| Tool | Description |
+| --- | --- |
+| `dashboard_stats` | High-level summary: device counts, health score, WAN status, latest speedtest. |
+| `network_summary` | Network totals plus per-node status (location, model, uptime, connected devices). |
+| `list_devices` | All client devices: name, MAC, IP, manufacturer, connection type, signal. |
+| `list_nodes` | The eero nodes (access points): location, model, status, uptime, backhaul. |
+| `collection_status` | Background data-collection health and freshness timestamps. |
+| `firmware_status` | Current firmware version and whether an update is available. |
+| `health_score` | Current network health score (0–100) and contributing factors. |
+| `wan_uptime` | WAN uptime percentages over 24 h / 7 d / 30 d. |
+| `recent_outages` | Recent WAN outages within `days` (default 30). |
+| `speedtest_analysis` | Speedtest trends (download/upload/latency) over `days` (default 30). |
+| `signal_summary` | Wireless signal-quality summary across all devices. |
+| `top_bandwidth_devices` | Top bandwidth consumers over `days` (default 7), up to `limit` (default 5). |
+
+## Notes
+
+- Data is served from eeroVista's local SQLite database, populated by the
+  background collectors. Use `collection_status` to confirm how fresh it is.
+- Because the tools reuse the REST handlers, their output matches the
+  corresponding endpoints documented in the [API Reference](api-reference.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,9 @@ prometheus-client>=0.19.0
 # MQTT (Home Assistant integration)
 paho-mqtt>=2.0.0
 
+# MCP server (read-only query API for AI agents)
+mcp>=1.27.0
+
 # HTTP Client (for testing)
 httpx>=0.25.0
 

--- a/src/config.py
+++ b/src/config.py
@@ -76,6 +76,13 @@ class Settings(BaseSettings):
     mqtt_qos: int = 1  # 0=at most once, 1=at least once, 2=exactly once
     mqtt_retain: bool = True  # retain messages for HA discovery
 
+    # MCP server (Model Context Protocol) - read-only query API for AI agents
+    # Exposes a curated set of network-status tools over Streamable HTTP at `mcp_path`.
+    # SECURITY: the endpoint has NO authentication. Only enable it when eeroVista is
+    # behind a trusted reverse proxy or on a network you control. Disabled by default.
+    mcp_enabled: bool = False
+    mcp_path: str = "/mcp"
+
     @field_validator("offline_consecutive_threshold")
     @classmethod
     def validate_offline_threshold(cls, v: int) -> int:
@@ -90,6 +97,17 @@ class Settings(BaseSettings):
         """Ensure minimum duration is non-negative."""
         if v < 0:
             raise ValueError("offline_min_duration_seconds must be >= 0")
+        return v
+
+    @field_validator("mcp_path")
+    @classmethod
+    def validate_mcp_path(cls, v: str) -> str:
+        """Ensure the MCP mount path is a non-root absolute path without a trailing slash."""
+        if not v.startswith("/"):
+            raise ValueError("mcp_path must start with '/'")
+        v = v.rstrip("/")
+        if not v:
+            raise ValueError("mcp_path must not be the root path '/'")
         return v
 
     def get_timezone(self) -> ZoneInfo:

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 
 import logging
 import sys
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -17,6 +17,7 @@ from src.utils.eero_patch import patch_eero_client  # noqa: F401
 
 from src.api import device_groups, health, notifications, prometheus, setup, web, zabbix
 from src.config import ensure_data_directory, get_settings
+from src.mcp_server import build_mcp_server
 from src.scheduler.jobs import get_scheduler
 from src.utils.database import init_database
 
@@ -31,6 +32,10 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+# Build the MCP server (when enabled) so it can be mounted on the app below.
+# Its Streamable HTTP session manager must run within the app lifespan.
+mcp_server = build_mcp_server(settings.mcp_path) if settings.mcp_enabled else None
 
 
 @asynccontextmanager
@@ -51,7 +56,13 @@ async def lifespan(app: FastAPI):
     scheduler = get_scheduler()
     scheduler.start()
 
-    yield
+    async with AsyncExitStack() as stack:
+        # Run the MCP Streamable HTTP session manager for the app's lifetime.
+        if mcp_server is not None:
+            await stack.enter_async_context(mcp_server.session_manager.run())
+            logger.info("MCP server enabled at %s (no authentication)", settings.mcp_path)
+
+        yield
 
     # Shutdown
     logger.info("Shutting down eeroVista")
@@ -77,6 +88,10 @@ app.include_router(prometheus.router)
 app.include_router(zabbix.router)
 app.include_router(device_groups.router)
 app.include_router(notifications.router)
+
+# Mount the MCP server (read-only network-status tools for AI agents) when enabled.
+if mcp_server is not None:
+    app.mount(settings.mcp_path, mcp_server.streamable_http_app())
 
 
 @app.get("/favicon.ico")

--- a/src/mcp_server/__init__.py
+++ b/src/mcp_server/__init__.py
@@ -1,0 +1,10 @@
+"""Model Context Protocol (MCP) server for eeroVista.
+
+Exposes a curated, read-only set of network-status tools over Streamable HTTP so
+that AI agents can query the eero mesh network in real time. The tools reuse the
+existing FastAPI route handlers, so their behaviour stays identical to the REST API.
+"""
+
+from src.mcp_server.server import build_mcp_server
+
+__all__ = ["build_mcp_server"]

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,0 +1,159 @@
+"""MCP server definition and tool registration.
+
+The tools delegate to the existing FastAPI route handlers in ``src.api.health``.
+Each handler accepts an :class:`EeroClientWrapper` (used for network-name
+resolution) and performs its own database access via ``get_db_context``. We build
+a short-lived client bound to a database session that stays open for the duration
+of the handler call.
+"""
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from src.api.health import analytics, routes
+from src.eero_client.client import EeroClientWrapper
+from src.utils.database import get_db_context
+
+logger = logging.getLogger(__name__)
+
+
+async def _query(
+    handler: Callable[..., Awaitable[Dict[str, Any]]], **kwargs: Any
+) -> Dict[str, Any]:
+    """Run an existing route handler with a freshly-built Eero client.
+
+    The database session is held open for the whole ``await`` so the client can
+    resolve the active network while the handler runs.
+    """
+    with get_db_context() as db:
+        client = EeroClientWrapper(db)
+        return await handler(client=client, **kwargs)
+
+
+def build_mcp_server(path: str = "/mcp") -> FastMCP:
+    """Create the eeroVista MCP server with its curated read-only tools.
+
+    Args:
+        path: Absolute path the Streamable HTTP endpoint is served at. The server
+            is mounted at this path by the main app, so the internal route is the
+            sub-app root ("/").
+    """
+    mcp = FastMCP(
+        name="eeroVista",
+        instructions=(
+            "Read-only tools for monitoring an eero mesh network in real time. "
+            "Use these to inspect network health, connected devices, eero nodes, "
+            "WAN uptime, outages, speedtests, signal quality, and bandwidth usage. "
+            "All tools are query-only; none change network configuration. "
+            "Most tools accept an optional `network` name; omit it to use the "
+            "default (first) network. Data comes from eeroVista's local database, "
+            "so call `collection_status` if you need to confirm how fresh it is."
+        ),
+        stateless_http=True,
+        json_response=True,
+        streamable_http_path="/",
+    )
+
+    @mcp.tool()
+    async def dashboard_stats(network: Optional[str] = None) -> Dict[str, Any]:
+        """Get a high-level dashboard summary for the network.
+
+        Returns current device counts (total/online), the network health score,
+        WAN status, guest-network state, and the latest speedtest result. This is
+        the best single tool for a quick "how is my network doing right now?".
+        """
+        return await _query(routes.dashboard_stats, network=network)
+
+    @mcp.tool()
+    async def network_summary(network: Optional[str] = None) -> Dict[str, Any]:
+        """Get a network summary including every eero node's status.
+
+        Returns total/online device counts, WAN status, guest-network state, and a
+        list of nodes with their location, model, gateway flag, online status,
+        connected-device count, and uptime.
+        """
+        return await _query(routes.get_network_summary, network=network)
+
+    @mcp.tool()
+    async def list_devices(network: Optional[str] = None) -> Dict[str, Any]:
+        """List all client devices known on the network.
+
+        Returns each device's name, MAC address, IP, manufacturer, connection type
+        (wired/wireless), the eero node it is connected to, online status, and
+        signal metrics where available.
+        """
+        return await _query(routes.get_devices, network=network)
+
+    @mcp.tool()
+    async def list_nodes(network: Optional[str] = None) -> Dict[str, Any]:
+        """List the eero nodes (access points) that make up the mesh.
+
+        Returns each node's location, model, gateway flag, online status,
+        connected-device count, uptime, and connection mode (wired/wireless
+        backhaul).
+        """
+        return await _query(routes.get_nodes, network=network)
+
+    @mcp.tool()
+    async def collection_status() -> Dict[str, Any]:
+        """Report background data-collection health and freshness.
+
+        Returns the last successful collection timestamps for each collector
+        (device, network, routing, speedtest) so you can tell how current the data
+        returned by the other tools is.
+        """
+        # collection_status takes no client argument, so call it directly.
+        return await routes.collection_status()
+
+    @mcp.tool()
+    async def firmware_status(network: Optional[str] = None) -> Dict[str, Any]:
+        """Check the firmware version and whether an update is available."""
+        return await _query(routes.get_firmware_update, network=network)
+
+    @mcp.tool()
+    async def health_score(network: Optional[str] = None) -> Dict[str, Any]:
+        """Get the current network health score (0-100) and its contributing factors."""
+        return await _query(analytics.get_network_health_score, network=network)
+
+    @mcp.tool()
+    async def wan_uptime(network: Optional[str] = None) -> Dict[str, Any]:
+        """Get WAN (internet) uptime percentages over the last 24 hours, 7 days, and 30 days."""
+        return await _query(analytics.get_network_uptime, network=network)
+
+    @mcp.tool()
+    async def recent_outages(days: int = 30, network: Optional[str] = None) -> Dict[str, Any]:
+        """List recent WAN outages (internet drops) within the given number of days."""
+        return await _query(analytics.get_network_outages, days=days, network=network)
+
+    @mcp.tool()
+    async def speedtest_analysis(days: int = 30, network: Optional[str] = None) -> Dict[str, Any]:
+        """Summarize recent speedtest results (download/upload/latency trends) over the given window."""
+        return await _query(analytics.get_speedtest_analysis, days=days, network=network)
+
+    @mcp.tool()
+    async def signal_summary(network: Optional[str] = None) -> Dict[str, Any]:
+        """Summarize wireless signal quality across all connected devices.
+
+        Highlights devices with weak signal that may have connectivity problems.
+        """
+        return await _query(analytics.get_devices_signal_summary, network=network)
+
+    @mcp.tool()
+    async def top_bandwidth_devices(
+        days: int = 7, limit: int = 5, network: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """List the devices using the most bandwidth over the given window.
+
+        Args:
+            days: Look-back window in days (default 7).
+            limit: Maximum number of devices to return (default 5).
+            network: Optional network name; defaults to the first network.
+        """
+        return await _query(
+            analytics.get_network_bandwidth_top_devices, days=days, limit=limit, network=network
+        )
+
+    logger.info("MCP server initialized with read-only eero network tools (mounted at %s)", path)
+    return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,95 @@
+"""Tests for the MCP server (src/mcp_server)."""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import Settings
+from src.mcp_server import build_mcp_server
+from src.mcp_server import server as mcp_module
+
+# The full curated tool set the server is expected to expose.
+EXPECTED_TOOLS = {
+    "dashboard_stats",
+    "network_summary",
+    "list_devices",
+    "list_nodes",
+    "collection_status",
+    "firmware_status",
+    "health_score",
+    "wan_uptime",
+    "recent_outages",
+    "speedtest_analysis",
+    "signal_summary",
+    "top_bandwidth_devices",
+}
+
+
+@pytest.mark.asyncio
+async def test_all_curated_tools_registered():
+    """The server registers exactly the curated read-only tool set."""
+    mcp = build_mcp_server("/mcp")
+    tools = await mcp.list_tools()
+    assert {t.name for t in tools} == EXPECTED_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_top_bandwidth_devices_schema():
+    """Tools surface their optional arguments in the input schema."""
+    mcp = build_mcp_server("/mcp")
+    tools = await mcp.list_tools()
+    top = next(t for t in tools if t.name == "top_bandwidth_devices")
+    assert set(top.inputSchema.get("properties", {})) == {"days", "limit", "network"}
+
+
+@pytest.mark.asyncio
+async def test_tool_delegates_to_route_handler():
+    """A tool call delegates to the existing route handler with the right args."""
+    mcp = build_mcp_server("/mcp")
+
+    fake_handler = AsyncMock(return_value={"ok": True})
+
+    @contextmanager
+    def fake_db_context():
+        yield MagicMock()
+
+    with patch.object(mcp_module.routes, "get_network_summary", fake_handler), patch.object(
+        mcp_module, "get_db_context", fake_db_context
+    ), patch.object(mcp_module, "EeroClientWrapper", MagicMock()):
+        await mcp.call_tool("network_summary", {"network": "Home"})
+
+    fake_handler.assert_awaited_once()
+    assert fake_handler.await_args.kwargs["network"] == "Home"
+
+
+@pytest.mark.asyncio
+async def test_collection_status_called_without_client():
+    """collection_status takes no client argument and is called directly."""
+    mcp = build_mcp_server("/mcp")
+    fake_handler = AsyncMock(return_value={"collectors": {}})
+
+    with patch.object(mcp_module.routes, "collection_status", fake_handler):
+        await mcp.call_tool("collection_status", {})
+
+    fake_handler.assert_awaited_once_with()
+
+
+def test_streamable_http_app_serves_at_root():
+    """The mounted sub-app serves the MCP endpoint at its root path."""
+    mcp = build_mcp_server("/mcp")
+    app = mcp.streamable_http_app()
+    assert "/" in [getattr(r, "path", None) for r in app.routes]
+
+
+def test_mcp_config_defaults_and_validation():
+    """MCP is opt-in and the mount path is validated/normalized."""
+    settings = Settings()
+    assert settings.mcp_enabled is False
+    assert settings.mcp_path == "/mcp"
+
+    assert Settings(mcp_path="/agent/").mcp_path == "/agent"
+    with pytest.raises(ValueError):
+        Settings(mcp_path="mcp")
+    with pytest.raises(ValueError):
+        Settings(mcp_path="/")


### PR DESCRIPTION
## Summary

Adds an optional **Model Context Protocol (MCP)** server so remote AI agents (e.g. Claude) can query eero network status in real time. It exposes a **curated set of 12 read-only tools** over the **Streamable HTTP** transport, mounted on the existing FastAPI web server.

The tools delegate to the existing `src/api/health` route handlers, so their output matches the REST API exactly — no duplicated query logic.

### Tools
`dashboard_stats`, `network_summary`, `list_devices`, `list_nodes`, `collection_status`, `firmware_status`, `health_score`, `wan_uptime`, `recent_outages`, `speedtest_analysis`, `signal_summary`, `top_bandwidth_devices`.

### Configuration
- **Disabled by default** (`MCP_ENABLED=false`).
- Mounted at a configurable path (`MCP_PATH`, default `/mcp`) on the existing port — a remote agent connects to `http://<host>:8080/mcp`.
- The Streamable HTTP session manager runs within the app lifespan via an `AsyncExitStack`.

### Security
The `/mcp` endpoint has **no authentication** (per design decision). This is documented in `docs/mcp.md` and `docker-compose.yml` with a clear warning to only enable it behind a trusted reverse proxy or on a controlled network. Like the rest of eeroVista, all tools are strictly read-only.

## Changes
- `src/mcp_server/` — new package (`build_mcp_server`, curated tools).
- `src/main.py` — mount the MCP sub-app + run its session manager in the lifespan when enabled.
- `src/config.py` — `mcp_enabled` / `mcp_path` settings with path validation.
- `requirements.txt` — `mcp>=1.27.0`.
- `docs/mcp.md` + index/nav link, `docker-compose.yml` env example, CHANGELOG entry.
- `tests/test_mcp_server.py` — tool registration, delegation, schema, config validation.
- Gitignores the local `.serena/` directory.

## Testing
- New test suite passes (6/6, run with the `eero` package stubbed locally).
- Verified the server builds, registers all 12 tools, mounts at `/mcp`, and the session manager lifecycle works.
- `ruff check`/`format` clean on new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)