### PR TITLE
chore: bump version to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.8.0] — 2026-06-13
 
 ### Added
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.7.2"
+__version__ = "2.8.0"


### PR DESCRIPTION
Bumps version to **2.8.0**, releasing the read-only MCP server for AI agents (#119).

- `src/__init__.py`: `2.7.2` → `2.8.0` (single source of truth; setup.py/pyproject read from it).
- `CHANGELOG.md`: finalize the `[Unreleased]` section as `[2.8.0] — 2026-06-13`.

Minor bump because #119 added a new feature (MCP server) with no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)