### PR TITLE
fix: MCP server behind a reverse proxy (2.8.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ ENV/
 env/
 .venv
 
+# uv (used ad hoc for tooling; project deps are pinned in requirements*.txt)
+uv.lock
+
 # IDEs
 .vscode/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.1] — 2026-06-13
+
+### Fixed
+
+- **MCP server behind a reverse proxy**: The MCP endpoint rejected proxied requests with `421 Invalid Host header` because the transport's DNS-rebinding protection only trusted `localhost`. Added `MCP_ALLOWED_HOSTS` (comma-separated public hostnames, or `*` to trust the proxy) so the configured host is accepted. Also enabled uvicorn proxy-header handling (`--proxy-headers`/`forwarded_allow_ips`) so the `/mcp` → `/mcp/` redirect respects `X-Forwarded-Proto` instead of downgrading to `http://`. Documented the trailing-slash endpoint (`/mcp/`) and proxy requirements.
+
 ## [2.8.0] — 2026-06-13
 
 ### Added

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -14,7 +14,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:uvicorn]
-command=/usr/local/bin/uvicorn src.main:app --host 0.0.0.0 --port 8080
+command=/usr/local/bin/uvicorn src.main:app --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips=*
 directory=/app
 autostart=true
 autorestart=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,10 @@ services:
       # trusted reverse proxy or on a network you control. See docs/mcp.md.
       # - MCP_ENABLED=true
       # - MCP_PATH=/mcp
+      # Behind a reverse proxy, set the public hostname(s) or DNS-rebinding
+      # protection rejects requests with "421 Invalid Host header". Use "*" to
+      # trust the proxy entirely. The proxy must also forward X-Forwarded-Proto.
+      # - MCP_ALLOWED_HOSTS=eero.example.com
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
       interval: 30s

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -30,8 +30,9 @@ your `docker-compose.yml`:
 
 ```yaml
 environment:
-  - MCP_ENABLED=true     # Enable the MCP server (default: false)
-  - MCP_PATH=/mcp        # Path the MCP endpoint is mounted at (default: /mcp)
+  - MCP_ENABLED=true                    # Enable the MCP server (default: false)
+  - MCP_PATH=/mcp                       # Path the endpoint is mounted at (default: /mcp)
+  - MCP_ALLOWED_HOSTS=eero.example.com  # Public hostname(s) when behind a proxy
 ```
 
 When enabled, the server is mounted on the existing eeroVista web server — same
@@ -42,13 +43,42 @@ defaults above, the endpoint is:
 http://<your-host>:8080/mcp
 ```
 
+### Running behind a reverse proxy
+
+The MCP transport has built-in DNS-rebinding protection that, by default, only
+accepts requests whose `Host` header is `localhost`. When eeroVista runs behind a
+reverse proxy (nginx, Caddy, etc.) the proxy forwards the **public** hostname, so
+you must allow it or every request is rejected with **`421 Invalid Host header`**:
+
+```yaml
+environment:
+  - MCP_ALLOWED_HOSTS=eero.example.com         # one or more, comma-separated
+  # - MCP_ALLOWED_HOSTS=*                       # or trust the proxy entirely
+```
+
+`localhost` is always allowed (for local access and health checks). Set
+`MCP_ALLOWED_HOSTS=*` to disable host checking completely and fully trust the
+proxy.
+
+Two more proxy requirements:
+
+- **Forward the original scheme.** eeroVista honors `X-Forwarded-Proto`, so make
+  sure your proxy sets it (`proxy_set_header X-Forwarded-Proto $scheme;` in
+  nginx). Otherwise the `/mcp` → `/mcp/` redirect is emitted as `http://` and TLS
+  clients refuse to follow it.
+- **Use the trailing slash.** The endpoint lives at `/mcp/`; a request to `/mcp`
+  is redirected. Point clients at the trailing-slash URL (or a path that maps to
+  it) to avoid a redirect round-trip: `https://eero.example.com/mcp/`.
+
+See [Reverse Proxy & HTTPS](reverse-proxy.md) for full proxy configuration.
+
 ## Connecting an agent
 
 Point any MCP client that supports the Streamable HTTP transport at the endpoint
 URL. For example, with the Claude Code CLI:
 
 ```bash
-claude mcp add --transport http eerovista http://<your-host>:8080/mcp
+claude mcp add --transport http eerovista https://eero.example.com/mcp/
 ```
 
 Or in an MCP client configuration file:
@@ -58,11 +88,14 @@ Or in an MCP client configuration file:
   "mcpServers": {
     "eerovista": {
       "transport": "http",
-      "url": "http://<your-host>:8080/mcp"
+      "url": "https://eero.example.com/mcp/"
     }
   }
 }
 ```
+
+> Note the **trailing slash** on `/mcp/` — see [Running behind a reverse
+> proxy](#running-behind-a-reverse-proxy) below.
 
 ## Available tools
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.8.0"
+__version__ = "2.8.1"

--- a/src/config.py
+++ b/src/config.py
@@ -82,6 +82,11 @@ class Settings(BaseSettings):
     # behind a trusted reverse proxy or on a network you control. Disabled by default.
     mcp_enabled: bool = False
     mcp_path: str = "/mcp"
+    # Comma-separated Host header values to accept (DNS-rebinding protection).
+    # Required when running behind a reverse proxy: set this to the public
+    # hostname(s) clients use, e.g. "eero.example.com". localhost is always
+    # allowed. Use "*" to trust the proxy entirely (disables host checking).
+    mcp_allowed_hosts: str = ""
 
     @field_validator("offline_consecutive_threshold")
     @classmethod
@@ -109,6 +114,10 @@ class Settings(BaseSettings):
         if not v:
             raise ValueError("mcp_path must not be the root path '/'")
         return v
+
+    def get_mcp_allowed_hosts(self) -> list[str]:
+        """Parse the comma-separated MCP allowed-hosts setting into a list."""
+        return [h.strip() for h in self.mcp_allowed_hosts.split(",") if h.strip()]
 
     def get_timezone(self) -> ZoneInfo:
         """Get the configured timezone as a ZoneInfo object."""

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,11 @@ logger = logging.getLogger(__name__)
 
 # Build the MCP server (when enabled) so it can be mounted on the app below.
 # Its Streamable HTTP session manager must run within the app lifespan.
-mcp_server = build_mcp_server(settings.mcp_path) if settings.mcp_enabled else None
+mcp_server = (
+    build_mcp_server(settings.mcp_path, allowed_hosts=settings.get_mcp_allowed_hosts())
+    if settings.mcp_enabled
+    else None
+)
 
 
 @asynccontextmanager
@@ -112,4 +116,8 @@ if __name__ == "__main__":
         port=8080,
         reload=settings.debug,
         log_level=log_level,
+        # Honor X-Forwarded-Proto/Host from a reverse proxy so generated URLs and
+        # redirects (e.g. the MCP /mcp -> /mcp/ redirect) use the correct scheme.
+        proxy_headers=True,
+        forwarded_allow_ips="*",
     )

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -11,12 +11,44 @@ import logging
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from src.api.health import analytics, routes
 from src.eero_client.client import EeroClientWrapper
 from src.utils.database import get_db_context
 
 logger = logging.getLogger(__name__)
+
+# Loopback hosts/origins are always trusted (local access and health checks).
+_LOCAL_HOSTS = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+_LOCAL_ORIGINS = ["http://127.0.0.1:*", "http://localhost:*", "http://[::1]:*"]
+
+
+def _build_transport_security(allowed_hosts: list[str]) -> TransportSecuritySettings:
+    """Build DNS-rebinding-protection settings for the given extra allowed hosts.
+
+    The MCP SDK enables host/origin checking by default and only trusts
+    localhost, which breaks reverse-proxy deployments (the proxy forwards the
+    public Host header). We extend the allow-list with the configured hostnames,
+    or disable protection entirely when ``*`` is supplied (trust the proxy).
+    """
+    if "*" in allowed_hosts:
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    hosts = list(_LOCAL_HOSTS)
+    origins = list(_LOCAL_ORIGINS)
+    for host in allowed_hosts:
+        # Allow both the bare host (default 443/80, no port in the Host header)
+        # and any explicit port via the SDK's ":*" wildcard.
+        hosts.extend([host, f"{host}:*"])
+        for scheme in ("https", "http"):
+            origins.extend([f"{scheme}://{host}", f"{scheme}://{host}:*"])
+
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
 
 
 async def _query(
@@ -32,13 +64,16 @@ async def _query(
         return await handler(client=client, **kwargs)
 
 
-def build_mcp_server(path: str = "/mcp") -> FastMCP:
+def build_mcp_server(path: str = "/mcp", allowed_hosts: Optional[list[str]] = None) -> FastMCP:
     """Create the eeroVista MCP server with its curated read-only tools.
 
     Args:
         path: Absolute path the Streamable HTTP endpoint is served at. The server
             is mounted at this path by the main app, so the internal route is the
             sub-app root ("/").
+        allowed_hosts: Extra Host header values to accept in addition to
+            localhost (needed behind a reverse proxy). Pass ``["*"]`` to trust the
+            proxy entirely and disable host/origin checking.
     """
     mcp = FastMCP(
         name="eeroVista",
@@ -54,6 +89,7 @@ def build_mcp_server(path: str = "/mcp") -> FastMCP:
         stateless_http=True,
         json_response=True,
         streamable_http_path="/",
+        transport_security=_build_transport_security(allowed_hosts or []),
     )
 
     @mcp.tool()
@@ -155,5 +191,9 @@ def build_mcp_server(path: str = "/mcp") -> FastMCP:
             analytics.get_network_bandwidth_top_devices, days=days, limit=limit, network=network
         )
 
-    logger.info("MCP server initialized with read-only eero network tools (mounted at %s)", path)
+    logger.info(
+        "MCP server initialized with read-only eero network tools (mounted at %s, allowed_hosts=%s)",
+        path,
+        allowed_hosts or "localhost-only",
+    )
     return mcp

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,10 +4,12 @@ from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.server.transport_security import TransportSecurityMiddleware
 
 from src.config import Settings
 from src.mcp_server import build_mcp_server
 from src.mcp_server import server as mcp_module
+from src.mcp_server.server import _build_transport_security
 
 # The full curated tool set the server is expected to expose.
 EXPECTED_TOOLS = {
@@ -87,9 +89,42 @@ def test_mcp_config_defaults_and_validation():
     settings = Settings()
     assert settings.mcp_enabled is False
     assert settings.mcp_path == "/mcp"
+    assert settings.get_mcp_allowed_hosts() == []
 
     assert Settings(mcp_path="/agent/").mcp_path == "/agent"
     with pytest.raises(ValueError):
         Settings(mcp_path="mcp")
     with pytest.raises(ValueError):
         Settings(mcp_path="/")
+
+
+def test_get_mcp_allowed_hosts_parsing():
+    """Comma-separated allowed hosts are split and trimmed."""
+    settings = Settings(mcp_allowed_hosts="eero.example.com, other.example.com ,")
+    assert settings.get_mcp_allowed_hosts() == ["eero.example.com", "other.example.com"]
+
+
+def test_transport_security_defaults_to_localhost_only():
+    """With no configured hosts, protection is on and only localhost passes."""
+    mw = TransportSecurityMiddleware(_build_transport_security([]))
+    assert mw.settings.enable_dns_rebinding_protection is True
+    assert mw._validate_host("localhost:8080") is True
+    assert mw._validate_host("eero.example.com") is False
+
+
+def test_transport_security_allows_configured_host():
+    """A configured host is accepted with or without an explicit port; others are not."""
+    mw = TransportSecurityMiddleware(_build_transport_security(["eero.example.com"]))
+    assert mw._validate_host("eero.example.com") is True
+    assert mw._validate_host("eero.example.com:443") is True
+    assert mw._validate_host("localhost:8080") is True
+    assert mw._validate_host("evil.example.com") is False
+    assert mw._validate_origin("https://eero.example.com") is True
+    # MCP clients typically send no Origin header; that must be allowed.
+    assert mw._validate_origin(None) is True
+
+
+def test_transport_security_wildcard_disables_protection():
+    """A '*' entry trusts the proxy entirely and disables host/origin checks."""
+    ts = _build_transport_security(["*"])
+    assert ts.enable_dns_rebinding_protection is False


### PR DESCRIPTION
## Problem

Enabling the MCP server (#119) on a production instance behind a reverse proxy fails: every request is rejected with **`421 Invalid Host header`**, and `/mcp` redirects to **`http://…/mcp/`** (TLS downgrade).

Root causes:
1. **DNS-rebinding protection** — FastMCP's Streamable HTTP transport enables host/origin checking by default and only trusts `localhost`. A reverse proxy forwards the *public* `Host`, which is rejected.
2. **Proxy scheme not honored** — uvicorn ran without `--proxy-headers`, so the `/mcp` → `/mcp/` trailing-slash redirect was emitted as `http://` instead of `https://`, and TLS clients refuse to follow it.

## Fix

- **`MCP_ALLOWED_HOSTS`** (comma-separated public hostnames; `*` trusts the proxy and disables host checking). Configured hosts are accepted with or without an explicit port; `localhost` stays allowed. Wired into a `TransportSecuritySettings` passed to `FastMCP`.
- **Proxy headers** — uvicorn now runs with `--proxy-headers --forwarded-allow-ips=*` (supervisor) and `proxy_headers=True` in the dev runner, so redirects/URLs respect `X-Forwarded-Proto`.
- **Docs** — `docs/mcp.md` gains a "Running behind a reverse proxy" section (allowed hosts, forwarded scheme, the trailing-slash `/mcp/` endpoint); `docker-compose.yml` example updated.
- Bump version to **2.8.1**.

## Testing

- New unit tests cover allowed-hosts parsing and the transport-security allow-list: localhost-only by default, configured host accepted (with/without port), `evil.example.com` rejected, missing `Origin` allowed, `*` disables protection. Full MCP suite: **10 passed**.
- Verified against the SDK's actual `TransportSecurityMiddleware` validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)