### PR TITLE
fix: publish web UI on host port 8080 to match docs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -132,7 +132,7 @@ jobs:
           for i in {1..30}; do
             if docker compose ps | grep eerovista | grep -q "Up"; then
               echo "Container is up, checking health endpoint..."
-              if curl -f -s http://localhost:9080/api/health > /dev/null 2>&1; then
+              if curl -f -s http://localhost:8080/api/health > /dev/null 2>&1; then
                 echo "✅ Container is healthy!"
                 break
               fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: eerovista
     restart: unless-stopped
     ports:
-      - "9080:8080"
+      - "8080:8080"
       - "5353:53/udp"  # DNS server (exposed on host port 5353)
       - "5353:53/tcp"  # DNS server TCP
     volumes:


### PR DESCRIPTION
## Problem

`docker-compose.yml` mapped the web UI to host port **9080** (`"9080:8080"`), but the README tells users to open `http://localhost:8080` after `docker compose up -d`. The container listens on 8080 internally (uvicorn binds `0.0.0.0:8080`), but nothing was published on host port 8080 — so the browser connection was refused, looking like the container never started listening.

The `docker run` example (`README.md:103`) already uses `-p 8080:8080`, so the two install paths were also inconsistent with each other.

## Fix

- `docker-compose.yml`: publish `8080:8080` to match the README and the `docker run` example.
- `.github/workflows/pr-validation.yml`: update the container health check to curl `http://localhost:8080/...` so CI matches the new mapping.

## Testing

- `docker compose config` validates.
- After `docker compose up -d`, `http://localhost:8080` reaches the web UI as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)