### PR TITLE
Migrate bandwidth-history to accumulated HourlyBandwidth data

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.9.0"
+__version__ = "2.9.1"

--- a/src/api/health/routes.py
+++ b/src/api/health/routes.py
@@ -843,7 +843,7 @@ async def get_device_bandwidth_history(
             raise HTTPException(status_code=404, detail="No network available")
 
         with get_db_context() as db:
-            from src.models.database import Device, DeviceConnection
+            from src.models.database import Device, HourlyBandwidth
 
             # Find device in this network
             device = db.query(Device).filter(
@@ -866,29 +866,27 @@ async def get_device_bandwidth_history(
             cutoff_local = now_local - timedelta(hours=hours)
             cutoff_time = cutoff_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
 
-            # Get bandwidth history
-            connections = (
-                db.query(DeviceConnection)
+            # Get bandwidth history from HourlyBandwidth
+            records = (
+                db.query(HourlyBandwidth)
                 .filter(
-                    DeviceConnection.device_id == device.id,
-                    DeviceConnection.timestamp >= cutoff_time,
+                    HourlyBandwidth.device_id == device.id,
+                    HourlyBandwidth.hour_start >= cutoff_time,
                 )
-                .order_by(DeviceConnection.timestamp.asc())
+                .order_by(HourlyBandwidth.hour_start.asc())
                 .all()
             )
 
             # Format data for graphing (convert timestamps to local timezone)
             history = []
-            for conn in connections:
-                # Database stores UTC naive datetime, convert to local timezone
-                timestamp_utc = conn.timestamp.replace(tzinfo=ZoneInfo("UTC"))
+            for rec in records:
+                timestamp_utc = rec.hour_start.replace(tzinfo=ZoneInfo("UTC"))
                 timestamp_local = timestamp_utc.astimezone(tz)
 
                 history.append({
                     "timestamp": timestamp_local.isoformat(),
-                    "download_mbps": conn.bandwidth_down_mbps,
-                    "upload_mbps": conn.bandwidth_up_mbps,
-                    "is_connected": conn.is_connected,
+                    "download_bytes": rec.download_bytes,
+                    "upload_bytes": rec.upload_bytes,
                 })
 
             return {
@@ -934,39 +932,42 @@ async def get_network_bandwidth_history(
             return {"hours": hours, "data_points": 0, "history": []}
 
         from datetime import timedelta
-        from sqlalchemy import func
+        from src.config import get_settings
+        from zoneinfo import ZoneInfo
+
+        settings = get_settings()
+        tz = settings.get_timezone()
 
         with get_db_context() as db:
-            from src.models.database import Device, DeviceConnection
+            from src.models.database import HourlyBandwidth
 
             # Calculate time range
-            cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
+            now_local = datetime.now(tz)
+            cutoff_local = now_local - timedelta(hours=hours)
+            cutoff_time = cutoff_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
 
-            # Get all connections in time range for devices in this network
-            # Group by timestamp and sum bandwidth across all devices
-            connections = (
-                db.query(
-                    DeviceConnection.timestamp,
-                    func.sum(DeviceConnection.bandwidth_down_mbps).label('total_download'),
-                    func.sum(DeviceConnection.bandwidth_up_mbps).label('total_upload'),
-                )
-                .join(Device, DeviceConnection.device_id == Device.id)
+            # Get network-wide bandwidth (device_id IS NULL)
+            records = (
+                db.query(HourlyBandwidth)
                 .filter(
-                    Device.network_name == network_name,
-                    DeviceConnection.timestamp >= cutoff_time
+                    HourlyBandwidth.network_name == network_name,
+                    HourlyBandwidth.device_id.is_(None),
+                    HourlyBandwidth.hour_start >= cutoff_time,
                 )
-                .group_by(DeviceConnection.timestamp)
-                .order_by(DeviceConnection.timestamp.asc())
+                .order_by(HourlyBandwidth.hour_start.asc())
                 .all()
             )
 
-            # Format data for graphing
+            # Format data for graphing (convert timestamps to local timezone)
             history = []
-            for conn in connections:
+            for rec in records:
+                timestamp_utc = rec.hour_start.replace(tzinfo=ZoneInfo("UTC"))
+                timestamp_local = timestamp_utc.astimezone(tz)
+
                 history.append({
-                    "timestamp": conn.timestamp.isoformat(),
-                    "download_mbps": float(conn.total_download) if conn.total_download else 0,
-                    "upload_mbps": float(conn.total_upload) if conn.total_upload else 0,
+                    "timestamp": timestamp_local.isoformat(),
+                    "download_bytes": rec.download_bytes,
+                    "upload_bytes": rec.upload_bytes,
                 })
 
             return {

--- a/src/services/signal_analysis_service.py
+++ b/src/services/signal_analysis_service.py
@@ -3,6 +3,7 @@
 import logging
 import math
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, func, text
@@ -162,8 +163,14 @@ def get_signal_history(
         ORDER BY timestamp
     """), {"device_id": device.id, "cutoff": cutoff, "step": step}).fetchall()
 
+    from src.config import get_settings
+    tz = get_settings().get_timezone()
+
     history = [
-        {"timestamp": str(r[0]), "signal_strength": r[1]}
+        {
+            "timestamp": datetime.fromisoformat(str(r[0])).replace(tzinfo=ZoneInfo("UTC")).astimezone(tz).isoformat(),
+            "signal_strength": r[1],
+        }
         for r in history_rows
     ]
 

--- a/src/templates/devices.html
+++ b/src/templates/devices.html
@@ -1559,30 +1559,21 @@
             const now = new Date();
             const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
-            // Aggregate data by hour
+            // Initialize 24 hourly buckets
             const hourlyData = Array(24).fill(null).map((_, hour) => ({
                 hour: hour,
                 hour_label: `${hour.toString().padStart(2, '0')}:00`,
                 download_mb: 0,
                 upload_mb: 0,
-                count: 0
             }));
 
-            // Sum bandwidth rates for each hour (convert Mbps to MB by dividing by 8 and multiplying by collection interval)
-            // Only include data from today (local timezone)
-            const secondsPerDataPoint = 30; // 30-second collection intervals
+            // Map each hourly record into its bucket (API returns accumulated bytes per hour)
             data.history.forEach(point => {
-                // Parse timezone-aware timestamp (API returns ISO timestamps with timezone offset)
                 const timestamp = new Date(point.timestamp);
-
-                // Filter: only include timestamps >= today at midnight
                 if (timestamp >= todayMidnight) {
                     const hour = timestamp.getHours();
-                    if (point.download_mbps !== null && point.upload_mbps !== null) {
-                        hourlyData[hour].download_mb += (point.download_mbps * secondsPerDataPoint) / 8;
-                        hourlyData[hour].upload_mb += (point.upload_mbps * secondsPerDataPoint) / 8;
-                        hourlyData[hour].count++;
-                    }
+                    hourlyData[hour].download_mb += point.download_bytes / 1000000;
+                    hourlyData[hour].upload_mb += point.upload_bytes / 1000000;
                 }
             });
 
@@ -1783,7 +1774,6 @@
             const now = new Date();
             const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
             const hourLabels = Array.from({ length: 24 }, (_, h) => `${h.toString().padStart(2, '0')}:00`);
-            const secondsPerDataPoint = 30;
 
             // Build per-member hourly buckets
             let totalDownload = 0, totalUpload = 0;
@@ -1797,10 +1787,10 @@
                 if (data.history) {
                     data.history.forEach(point => {
                         const timestamp = new Date(point.timestamp);
-                        if (timestamp >= todayMidnight && point.download_mbps !== null && point.upload_mbps !== null) {
+                        if (timestamp >= todayMidnight && point.download_bytes !== null && point.upload_bytes !== null) {
                             const hour = timestamp.getHours();
-                            dlBuckets[hour] += (point.download_mbps * secondsPerDataPoint) / 8;
-                            ulBuckets[hour] += (point.upload_mbps * secondsPerDataPoint) / 8;
+                            dlBuckets[hour] += point.download_bytes / 1000000;
+                            ulBuckets[hour] += point.upload_bytes / 1000000;
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- Migrates `/devices/{mac}/bandwidth-history` and `/network/bandwidth-history` from polling-based `DeviceConnection` rate snapshots (Mbps) to accumulated `HourlyBandwidth` byte totals
- Changes API field names from `download_mbps`/`upload_mbps` to `download_bytes`/`upload_bytes`
- Updates frontend to convert bytes→MB for display and removes the old rate×interval approximation
- Fixes UTC timezone bug in signal quality history timestamps (`signal_analysis_service.py`)
- Bumps version to 2.9.1

Closes #125

## Test plan
- [ ] Verify `HourlyBandwidth` table has per-device records (`device_id IS NOT NULL`)
- [ ] Check `/devices/{mac}/bandwidth-history` returns `download_bytes`/`upload_bytes` fields
- [ ] Check `/network/bandwidth-history` returns `download_bytes`/`upload_bytes` fields
- [ ] Confirm hourly bandwidth charts render correctly on device detail pages
- [ ] Confirm signal quality history timestamps display in local timezone

Authored by Merlin 🪄