### PR TITLE
Fix per-device bandwidth data never being collected

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.9.1"
+__version__ = "2.9.2"

--- a/src/collectors/data_usage_collector.py
+++ b/src/collectors/data_usage_collector.py
@@ -117,12 +117,12 @@ class DataUsageCollector(BaseCollector):
             logger.debug(f"No device data_usage response for network '{network_name}'")
             return
 
-        # The device endpoint returns per-device entries
-        data = result.get("data") if isinstance(result, dict) else result
-        if isinstance(data, dict):
-            devices_list = data.get("devices", [])
-        elif isinstance(data, list):
-            devices_list = data
+        # The API client already unwraps the outer {"data": ...} envelope,
+        # so result is the inner payload directly.
+        if isinstance(result, dict):
+            devices_list = result.get("devices", [])
+        elif isinstance(result, list):
+            devices_list = result
         else:
             devices_list = []
 


### PR DESCRIPTION
## Summary
- Fixes double-unwrapping bug in `DataUsageCollector._collect_device_usage()` — the eero API client already strips the `{data: ...}` envelope, but the collector was calling `result.get("data")` again, which returned `None` and made `devices_list` always empty
- Per-device `HourlyBandwidth` records were never being stored (0 rows in DB)
- This is why per-device bandwidth charts and "Top Bandwidth Consumers" showed no data since 2.9.0
- Bumps version to 2.9.2

Closes #125

## Test plan
- [ ] Deploy and verify `HourlyBandwidth` per-device records start appearing after next collection cycle
- [ ] Check per-device bandwidth charts show data
- [ ] Check "Top Bandwidth Consumers" populates

Authored by Merlin 🪄