### PR TITLE
Debug: log per-device data_usage response shape

### DIFF
--- a/src/collectors/data_usage_collector.py
+++ b/src/collectors/data_usage_collector.py
@@ -119,12 +119,18 @@ class DataUsageCollector(BaseCollector):
 
         # The API client already unwraps the outer {"data": ...} envelope,
         # so result is the inner payload directly.
+        logger.info(
+            f"Device data_usage response: type={type(result).__name__}, "
+            f"keys={list(result.keys()) if isinstance(result, dict) else 'N/A'}, "
+            f"len={len(result) if isinstance(result, (list, dict)) else 'N/A'}"
+        )
         if isinstance(result, dict):
             devices_list = result.get("devices", [])
         elif isinstance(result, list):
             devices_list = result
         else:
             devices_list = []
+        logger.info(f"Extracted devices_list: len={len(devices_list)}")
 
         # Pre-fetch all devices for this network to avoid N+1 queries
         all_devices = (


### PR DESCRIPTION
## Summary
- Adds temporary debug logging to see the actual response shape from the eero per-device data_usage endpoint
- Need this to diagnose why per-device HourlyBandwidth records still aren't being stored after the double-unwrap fix in v2.9.2

Authored by Merlin 🪄