### PR TITLE
Fix per-device data collection, revert hourly to rate data

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 
 # NOTE: This is the single source of truth for version numbers.
 # setup.py and pyproject.toml read from this value.
-__version__ = "2.9.2"
+__version__ = "2.9.3"

--- a/src/api/health/routes.py
+++ b/src/api/health/routes.py
@@ -843,7 +843,7 @@ async def get_device_bandwidth_history(
             raise HTTPException(status_code=404, detail="No network available")
 
         with get_db_context() as db:
-            from src.models.database import Device, HourlyBandwidth
+            from src.models.database import Device, DeviceConnection
 
             # Find device in this network
             device = db.query(Device).filter(
@@ -866,27 +866,29 @@ async def get_device_bandwidth_history(
             cutoff_local = now_local - timedelta(hours=hours)
             cutoff_time = cutoff_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
 
-            # Get bandwidth history from HourlyBandwidth
-            records = (
-                db.query(HourlyBandwidth)
+            # Per-device hourly data uses DeviceConnection rate snapshots
+            # (eero API doesn't provide per-device hourly accumulated data)
+            connections = (
+                db.query(DeviceConnection)
                 .filter(
-                    HourlyBandwidth.device_id == device.id,
-                    HourlyBandwidth.hour_start >= cutoff_time,
+                    DeviceConnection.device_id == device.id,
+                    DeviceConnection.timestamp >= cutoff_time,
                 )
-                .order_by(HourlyBandwidth.hour_start.asc())
+                .order_by(DeviceConnection.timestamp.asc())
                 .all()
             )
 
             # Format data for graphing (convert timestamps to local timezone)
             history = []
-            for rec in records:
-                timestamp_utc = rec.hour_start.replace(tzinfo=ZoneInfo("UTC"))
+            for conn in connections:
+                timestamp_utc = conn.timestamp.replace(tzinfo=ZoneInfo("UTC"))
                 timestamp_local = timestamp_utc.astimezone(tz)
 
                 history.append({
                     "timestamp": timestamp_local.isoformat(),
-                    "download_bytes": rec.download_bytes,
-                    "upload_bytes": rec.upload_bytes,
+                    "download_mbps": conn.bandwidth_down_mbps,
+                    "upload_mbps": conn.bandwidth_up_mbps,
+                    "is_connected": conn.is_connected,
                 })
 
             return {

--- a/src/collectors/data_usage_collector.py
+++ b/src/collectors/data_usage_collector.py
@@ -106,7 +106,12 @@ class DataUsageCollector(BaseCollector):
         )
 
     def _collect_device_usage(self, network_name: str, today_window: tuple[str, str, str, datetime]) -> None:
-        """Fetch and store per-device data_usage."""
+        """Fetch and store per-device data_usage.
+
+        The eero per-device endpoint returns flat daily totals per device
+        (upload/download in bytes) under a "values" key — it does NOT provide
+        hourly series breakdowns like the network-level endpoint does.
+        """
         start, end, tz_name, now_local = today_window
 
         result = self.eero_client.get_data_usage_devices(
@@ -117,20 +122,14 @@ class DataUsageCollector(BaseCollector):
             logger.debug(f"No device data_usage response for network '{network_name}'")
             return
 
-        # The API client already unwraps the outer {"data": ...} envelope,
-        # so result is the inner payload directly.
-        logger.info(
-            f"Device data_usage response: type={type(result).__name__}, "
-            f"keys={list(result.keys()) if isinstance(result, dict) else 'N/A'}, "
-            f"len={len(result) if isinstance(result, (list, dict)) else 'N/A'}"
-        )
+        # The API client already unwraps the outer {"data": ...} envelope.
+        # The per-device response uses "values" (not "devices") as the key.
         if isinstance(result, dict):
-            devices_list = result.get("devices", [])
+            devices_list = result.get("values", result.get("devices", []))
         elif isinstance(result, list):
             devices_list = result
         else:
             devices_list = []
-        logger.info(f"Extracted devices_list: len={len(devices_list)}")
 
         # Pre-fetch all devices for this network to avoid N+1 queries
         all_devices = (
@@ -154,21 +153,24 @@ class DataUsageCollector(BaseCollector):
                 logger.debug(f"Unknown device MAC {mac} in data_usage response, skipping")
                 continue
 
+            # Per-device entries have flat upload/download totals (no hourly series).
+            # Try series extraction first (in case the API adds it later), fall back
+            # to flat fields.
             series = self._extract_series(device_entry)
-            if not series:
-                continue
+            if series:
+                upload_series = series.get("upload", {})
+                download_series = series.get("download", {})
+                self._store_hourly_values(
+                    network_name, device.id,
+                    download_series.get("values", []),
+                    upload_series.get("values", []),
+                )
+                download_sum = download_series.get("sum", 0) or 0
+                upload_sum = upload_series.get("sum", 0) or 0
+            else:
+                download_sum = device_entry.get("download", 0) or 0
+                upload_sum = device_entry.get("upload", 0) or 0
 
-            upload_series = series.get("upload", {})
-            download_series = series.get("download", {})
-
-            self._store_hourly_values(
-                network_name, device.id,
-                download_series.get("values", []),
-                upload_series.get("values", []),
-            )
-
-            download_sum = download_series.get("sum", 0) or 0
-            upload_sum = upload_series.get("sum", 0) or 0
             self._update_daily_from_server(network_name, device.id, now_local.date(), download_sum, upload_sum)
             devices_updated += 1
 

--- a/src/templates/devices.html
+++ b/src/templates/devices.html
@@ -1559,21 +1559,26 @@
             const now = new Date();
             const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
-            // Initialize 24 hourly buckets
+            // Aggregate data by hour
             const hourlyData = Array(24).fill(null).map((_, hour) => ({
                 hour: hour,
                 hour_label: `${hour.toString().padStart(2, '0')}:00`,
                 download_mb: 0,
                 upload_mb: 0,
+                count: 0
             }));
 
-            // Map each hourly record into its bucket (API returns accumulated bytes per hour)
+            // Sum bandwidth rates for each hour (convert Mbps to MB by dividing by 8 and multiplying by collection interval)
+            const secondsPerDataPoint = 30; // 30-second collection intervals
             data.history.forEach(point => {
                 const timestamp = new Date(point.timestamp);
                 if (timestamp >= todayMidnight) {
                     const hour = timestamp.getHours();
-                    hourlyData[hour].download_mb += point.download_bytes / 1000000;
-                    hourlyData[hour].upload_mb += point.upload_bytes / 1000000;
+                    if (point.download_mbps !== null && point.upload_mbps !== null) {
+                        hourlyData[hour].download_mb += (point.download_mbps * secondsPerDataPoint) / 8;
+                        hourlyData[hour].upload_mb += (point.upload_mbps * secondsPerDataPoint) / 8;
+                        hourlyData[hour].count++;
+                    }
                 }
             });
 
@@ -1777,6 +1782,7 @@
 
             // Build per-member hourly buckets
             let totalDownload = 0, totalUpload = 0;
+            const secondsPerDataPoint = 30;
             const datasets = [];
             responses.forEach((data, i) => {
                 const color = getGroupMemberColor(i, responses.length);
@@ -1787,10 +1793,10 @@
                 if (data.history) {
                     data.history.forEach(point => {
                         const timestamp = new Date(point.timestamp);
-                        if (timestamp >= todayMidnight && point.download_bytes !== null && point.upload_bytes !== null) {
+                        if (timestamp >= todayMidnight && point.download_mbps !== null && point.upload_mbps !== null) {
                             const hour = timestamp.getHours();
-                            dlBuckets[hour] += point.download_bytes / 1000000;
-                            ulBuckets[hour] += point.upload_bytes / 1000000;
+                            dlBuckets[hour] += (point.download_mbps * secondsPerDataPoint) / 8;
+                            ulBuckets[hour] += (point.upload_mbps * secondsPerDataPoint) / 8;
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- **Collector fix**: eero per-device `data_usage/devices` endpoint returns data under `"values"` key (not `"devices"`), and entries have flat `upload`/`download` daily totals — no hourly `series` breakdowns. Fixed key lookup and added fallback to flat fields.
- **Revert per-device hourly**: since eero doesn't provide per-device hourly data, reverted the device `bandwidth-history` endpoint back to `DeviceConnection` rate snapshots (Mbps). This preserves hourly granularity on device pages.
- **Frontend revert**: per-device charts use Mbps rate fields again.
- Network-level hourly endpoint stays on `HourlyBandwidth` accumulated data (working correctly).
- Bumps to v2.9.3.

Verified locally: collector now stores 69 devices per collection run. Per-device daily totals confirmed working (Sentry: 17.2 GB down, 20.0 GB up today).

## Test plan
- [ ] Deploy and verify per-device hourly charts show data again
- [ ] Verify "Top Bandwidth Consumers" populates with daily per-device data
- [ ] Verify network-level hourly chart still works from HourlyBandwidth
- [ ] Check container logs for `Updated data_usage for N devices`

Authored by Merlin 🪄